### PR TITLE
chore: harden release metadata and docs

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,128 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the project maintainers via the channel documented in
+[SECURITY.md](SECURITY.md) or via the repository contact mechanisms.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct
+enforcement ladder](https://github.com/mozilla/diversity).
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.
+
+[homepage]: https://www.contributor-covenant.org

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > **The Reversible Privacy Firewall for Generative AI in the Java Ecosystem.**
 > [📖 Read the Documentation](https://catalin87.github.io/spring-prism/)
 
-Spring Prism is a rigorous, zero-dependency data privacy framework designed specifically for integration with **Spring AI** and **LangChain4j**. It seamlessly sits between your robust backend infrastructure and untrusted Large Language Model providers (OpenAI, Anthropic, Mistral), ensuring sensitive data mathematically *cannot* escape your enterprise boundaries.
+Spring Prism is a rigorous, zero-dependency data privacy framework designed specifically for integration with **Spring AI**, with **LangChain4j** planned next in the roadmap. It seamlessly sits between your robust backend infrastructure and untrusted Large Language Model providers (OpenAI, Anthropic, Mistral), ensuring sensitive data mathematically *cannot* escape your enterprise boundaries.
 
 ---
 
@@ -48,7 +48,7 @@ sequenceDiagram
 
 ## 🚀 Quick Start Snippet
 
-Inject Spring Prism completely invisibly onto your `ChatClient` using our non-invasive architectural interceptors:
+Inject Spring Prism onto your Spring AI `ChatClient` using the current advisor integration:
 
 ```java
 @Configuration
@@ -87,8 +87,11 @@ Spring Prism executes strict isolation through a robust Maven multi-module archi
 | Maven Module | Architectural Role |
 | -------------- | ------- |
 | `prism-core` | The zero-dependency cryptographic Vault, generic `PiiDetector` interfaces, and string boundaries. |
+| `prism-spring-ai` | Spring AI advisor integration for synchronous and streaming chat interception. |
 | `prism-spring-boot-starter` | Instantly initializes Spring AI auto-configurations and exposes cleanly configurable `application.yml` localization boundaries. |
 | `prism-dashboard` | An optional, self-hosted visual interface rendering Micrometer usage statistics on exactly what PII parameters were prevented from escaping to the LLM. |
+
+LangChain4j support is planned, but is not shipped on this branch yet.
 
 ## 📜 Governance & Licensing
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,36 @@
     <version>1.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Spring Prism Parent</name>
-    <description>Reversible PII pseudonymization firewall for Spring AI and LangChain4j</description>
+    <description>Reversible PII pseudonymization firewall for Spring AI, with planned LangChain4j support.</description>
+    <url>https://github.com/catalin87/spring-prism</url>
+
+    <licenses>
+        <license>
+            <name>European Union Public Licence v1.2</name>
+            <url>https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <organization>
+        <name>Spring Prism</name>
+        <url>https://github.com/catalin87/spring-prism</url>
+    </organization>
+
+    <developers>
+        <developer>
+            <id>catalin87</id>
+            <name>Catalin Dordea</name>
+            <url>https://github.com/catalin87</url>
+        </developer>
+    </developers>
+
+    <scm>
+        <connection>scm:git:https://github.com/catalin87/spring-prism.git</connection>
+        <developerConnection>scm:git:git@github.com:catalin87/spring-prism.git</developerConnection>
+        <url>https://github.com/catalin87/spring-prism</url>
+        <tag>HEAD</tag>
+    </scm>
 
     <modules>
         <module>prism-bom</module>
@@ -204,6 +233,19 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>3.3.1</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.11.2</version>
+                <configuration>
+                    <doclint>none</doclint>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/website/docs/intro.md
+++ b/website/docs/intro.md
@@ -4,7 +4,7 @@ sidebar_position: 1
 
 # Introduction
 
-Spring Prism is a reversible PII (Personally Identifiable Information) pseudonymization firewall for **Spring AI** and **LangChain4j**.
+Spring Prism is a reversible PII (Personally Identifiable Information) pseudonymization firewall for **Spring AI**, with **LangChain4j** planned as the next integration milestone.
 
 In the era of LLMs, data privacy is paramount. Spring Prism acts as a transparent layer that detects, redacts, and pseudonymizes sensitive data before it leaves your infrastructure, and restores it when it returns.
 
@@ -13,6 +13,7 @@ In the era of LLMs, data privacy is paramount. Spring Prism acts as a transparen
 - **Automated Detection**: Built-in support for multiple locales (US, EU, Universal).
 - **Reversible Tokens**: Non-reversible HMAC-SHA256 signatures ensure data security while allowing seamless restoration.
 - **Spring AI Integration**: Plugs directly into `ChatClient` via Advisors.
+- **LangChain4j Roadmap**: A dedicated LangChain4j module is planned, but not shipped in the current release line.
 - **Type-Safe & Performance-Oriented**: Built with Java 21, utilizing Virtual Threads for efficient I/O-bound scanning.
 - **Decoupled Architecture**: `prism-core` is zero-dependency, making it portable and lightweight.
 

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -11,7 +11,7 @@ import {themes as prismThemes} from 'prism-react-renderer';
 /** @type {import('@docusaurus/types').Config} */
 const config = {
   title: 'Spring Prism',
-  tagline: 'Reversible PII pseudonymization firewall for Spring AI and LangChain4j',
+  tagline: 'Reversible PII pseudonymization firewall for Spring AI, with LangChain4j planned next',
   favicon: 'img/favicon.ico',
 
   // Future flags, see https://docusaurus.io/docs/api/docusaurus-config#future

--- a/website/src/components/HomepageFeatures/index.js
+++ b/website/src/components/HomepageFeatures/index.js
@@ -28,8 +28,8 @@ const FeatureList = [
     Svg: require('@site/static/img/undraw_docusaurus_react.svg').default,
     description: (
       <>
-        Seamlessly integrates as a non-invasive Advisor for Spring AI and LangChain4j,
-        pseudonymizing prompts and restoring responses automatically.
+        Seamlessly integrates as a non-invasive Advisor for Spring AI today,
+        with LangChain4j support planned in the next integration milestone.
       </>
     ),
   },


### PR DESCRIPTION
## Summary
- add missing OSS governance conduct file
- complete root POM release metadata and publishing plugin declarations
- align README and Docusaurus wording with shipped Spring AI support
- mark LangChain4j as planned rather than currently shipped

## Verification
- mvn -Dmaven.repo.local=/tmp/spring-prism-m2 verify