### PR TITLE
feat: harden starter configuration defaults

### DIFF
--- a/prism-spring-boot-starter/src/main/java/io/github/catalin87/prism/boot/autoconfigure/SpringPrismAutoConfiguration.java
+++ b/prism-spring-boot-starter/src/main/java/io/github/catalin87/prism/boot/autoconfigure/SpringPrismAutoConfiguration.java
@@ -32,6 +32,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.data.redis.core.StringRedisTemplate;
@@ -39,6 +40,11 @@ import org.springframework.data.redis.core.StringRedisTemplate;
 /** Auto-configuration entry point for Spring Prism. */
 @AutoConfiguration
 @ConditionalOnClass(PrismChatClientAdvisor.class)
+@ConditionalOnProperty(
+    prefix = "spring.prism",
+    name = "enabled",
+    havingValue = "true",
+    matchIfMissing = true)
 @EnableConfigurationProperties(SpringPrismProperties.class)
 public class SpringPrismAutoConfiguration {
 
@@ -68,8 +74,8 @@ public class SpringPrismAutoConfiguration {
       TokenGenerator prismTokenGenerator,
       SpringPrismProperties properties,
       StringRedisTemplate stringRedisTemplate) {
-    Duration ttl = properties.getTtl().isNegative() ? Duration.ofSeconds(1) : properties.getTtl();
-    byte[] secret = properties.getAppSecret().getBytes(StandardCharsets.UTF_8);
+    Duration ttl = properties.getTtl();
+    byte[] secret = secretKey(properties);
     return new RedisPrismVault(stringRedisTemplate, prismTokenGenerator, secret, ttl);
   }
 
@@ -78,7 +84,7 @@ public class SpringPrismAutoConfiguration {
   @ConditionalOnMissingClass("org.springframework.data.redis.core.StringRedisTemplate")
   PrismVault prismVault(TokenGenerator prismTokenGenerator, SpringPrismProperties properties) {
     long ttlSeconds = Math.max(1L, properties.getTtl().toSeconds());
-    byte[] secret = properties.getAppSecret().getBytes(StandardCharsets.UTF_8);
+    byte[] secret = secretKey(properties);
     return new DefaultPrismVault(prismTokenGenerator, secret, ttlSeconds);
   }
 
@@ -88,7 +94,7 @@ public class SpringPrismAutoConfiguration {
   PrismVault fallbackPrismVault(
       TokenGenerator prismTokenGenerator, SpringPrismProperties properties) {
     long ttlSeconds = Math.max(1L, properties.getTtl().toSeconds());
-    byte[] secret = properties.getAppSecret().getBytes(StandardCharsets.UTF_8);
+    byte[] secret = secretKey(properties);
     return new DefaultPrismVault(prismTokenGenerator, secret, ttlSeconds);
   }
 
@@ -134,5 +140,9 @@ public class SpringPrismAutoConfiguration {
       @Qualifier("springPrismRulePacks") List<PrismRulePack> springPrismRulePacks,
       PrismVault prismVault) {
     return new MetricsController(prismRuntimeMetrics, springPrismRulePacks, prismVault);
+  }
+
+  private static byte[] secretKey(SpringPrismProperties properties) {
+    return properties.getAppSecret().getBytes(StandardCharsets.UTF_8);
   }
 }

--- a/prism-spring-boot-starter/src/main/java/io/github/catalin87/prism/boot/autoconfigure/SpringPrismProperties.java
+++ b/prism-spring-boot-starter/src/main/java/io/github/catalin87/prism/boot/autoconfigure/SpringPrismProperties.java
@@ -27,13 +27,24 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public class SpringPrismProperties {
 
   private static final String DEFAULT_SECRET = "spring-prism-change-me";
+  private static final Duration DEFAULT_TTL = Duration.ofMinutes(30);
+  private static final List<String> DEFAULT_LOCALES = List.of("UNIVERSAL");
 
+  private boolean enabled = true;
   private boolean securityStrictMode;
-  private Duration ttl = Duration.ofMinutes(30);
+  private Duration ttl = DEFAULT_TTL;
   private String appSecret = DEFAULT_SECRET;
-  private List<String> locales = new ArrayList<>(List.of("UNIVERSAL"));
+  private List<String> locales = new ArrayList<>(DEFAULT_LOCALES);
   private List<CustomRule> customRules = new ArrayList<>();
   private Set<String> disabledRules = new LinkedHashSet<>();
+
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  public void setEnabled(boolean enabled) {
+    this.enabled = enabled;
+  }
 
   public boolean isSecurityStrictMode() {
     return securityStrictMode;
@@ -47,7 +58,12 @@ public class SpringPrismProperties {
     return ttl;
   }
 
+  /** Sets the vault TTL, falling back to the starter default for null or non-positive values. */
   public void setTtl(Duration ttl) {
+    if (ttl == null || ttl.isZero() || ttl.isNegative()) {
+      this.ttl = DEFAULT_TTL;
+      return;
+    }
     this.ttl = ttl;
   }
 
@@ -55,7 +71,12 @@ public class SpringPrismProperties {
     return appSecret;
   }
 
+  /** Sets the HMAC application secret, falling back to the starter default when blank. */
   public void setAppSecret(String appSecret) {
+    if (appSecret == null || appSecret.isBlank()) {
+      this.appSecret = DEFAULT_SECRET;
+      return;
+    }
     this.appSecret = appSecret;
   }
 
@@ -63,8 +84,13 @@ public class SpringPrismProperties {
     return locales;
   }
 
+  /** Sets the active locales, defaulting back to {@code UNIVERSAL} when the list is empty. */
   public void setLocales(List<String> locales) {
-    this.locales = locales;
+    if (locales == null || locales.isEmpty()) {
+      this.locales = new ArrayList<>(DEFAULT_LOCALES);
+      return;
+    }
+    this.locales = new ArrayList<>(locales);
   }
 
   public List<CustomRule> getCustomRules() {
@@ -72,7 +98,7 @@ public class SpringPrismProperties {
   }
 
   public void setCustomRules(List<CustomRule> customRules) {
-    this.customRules = customRules;
+    this.customRules = customRules == null ? new ArrayList<>() : new ArrayList<>(customRules);
   }
 
   public Set<String> getDisabledRules() {
@@ -80,7 +106,8 @@ public class SpringPrismProperties {
   }
 
   public void setDisabledRules(Set<String> disabledRules) {
-    this.disabledRules = disabledRules;
+    this.disabledRules =
+        disabledRules == null ? new LinkedHashSet<>() : new LinkedHashSet<>(disabledRules);
   }
 
   /** Placeholder binding model for future property-defined detectors. */

--- a/prism-spring-boot-starter/src/test/java/io/github/catalin87/prism/boot/autoconfigure/SpringPrismAutoConfigurationTest.java
+++ b/prism-spring-boot-starter/src/test/java/io/github/catalin87/prism/boot/autoconfigure/SpringPrismAutoConfigurationTest.java
@@ -23,6 +23,7 @@ import io.github.catalin87.prism.core.PrismVault;
 import io.github.catalin87.prism.core.detector.universal.EmailDetector;
 import io.github.catalin87.prism.core.ruleset.EuropeRulePack;
 import io.github.catalin87.prism.core.ruleset.UniversalRulePack;
+import io.github.catalin87.prism.core.vault.DefaultPrismVault;
 import io.github.catalin87.prism.spring.ai.advisor.PrismChatClientAdvisor;
 import io.github.catalin87.prism.spring.ai.advisor.PrismMetricsSink;
 import io.micrometer.observation.ObservationRegistry;
@@ -58,6 +59,18 @@ class SpringPrismAutoConfigurationTest {
           assertThat(rulePacks).hasSize(1);
           assertThat(rulePacks.get(0)).isInstanceOf(UniversalRulePack.class);
         });
+  }
+
+  @Test
+  void disabledPropertySkipsAutoConfiguration() {
+    contextRunner
+        .withPropertyValues("spring.prism.enabled=false")
+        .run(
+            context -> {
+              assertThat(context).doesNotHaveBean(PrismVault.class);
+              assertThat(context).doesNotHaveBean(PrismChatClientAdvisor.class);
+              assertThat(context).doesNotHaveBean(MetricsController.class);
+            });
   }
 
   @Test
@@ -100,6 +113,22 @@ class SpringPrismAutoConfigurationTest {
   }
 
   @Test
+  void invalidPropertyValuesFallBackToStarterDefaults() {
+    contextRunner
+        .withPropertyValues(
+            "spring.prism.ttl=-15s", "spring.prism.app-secret=   ", "spring.prism.locales=")
+        .run(
+            context -> {
+              SpringPrismProperties properties = context.getBean(SpringPrismProperties.class);
+
+              assertThat(properties.getTtl()).isEqualTo(Duration.ofMinutes(30));
+              assertThat(properties.getAppSecret()).isEqualTo("spring-prism-change-me");
+              assertThat(properties.getLocales()).containsExactly("UNIVERSAL");
+              assertThat(context.getBean(PrismVault.class)).isInstanceOf(DefaultPrismVault.class);
+            });
+  }
+
+  @Test
   void redisTemplateSwitchesVaultImplementation() {
     contextRunner
         .withUserConfiguration(RedisTemplateConfiguration.class)
@@ -108,6 +137,15 @@ class SpringPrismAutoConfigurationTest {
               assertThat(context).hasSingleBean(PrismVault.class);
               assertThat(context.getBean(PrismVault.class)).isInstanceOf(RedisPrismVault.class);
             });
+  }
+
+  @Test
+  void defaultVaultRemainsLocalWhenRedisBeanIsAbsent() {
+    contextRunner.run(
+        context -> {
+          assertThat(context).hasSingleBean(PrismVault.class);
+          assertThat(context.getBean(PrismVault.class)).isInstanceOf(DefaultPrismVault.class);
+        });
   }
 
   @Test
@@ -141,6 +179,22 @@ class SpringPrismAutoConfigurationTest {
   }
 
   @Test
+  void incompleteCustomRulesAreIgnored() {
+    contextRunner
+        .withPropertyValues(
+            "spring.prism.custom-rules[0].name=   ",
+            "spring.prism.custom-rules[0].pattern=ID-\\d{5}",
+            "spring.prism.custom-rules[1].name=INTERNAL_ID",
+            "spring.prism.custom-rules[1].pattern=   ")
+        .run(
+            context -> {
+              List<PrismRulePack> rulePacks = getRulePacks(context);
+              assertThat(rulePacks).hasSize(1);
+              assertThat(rulePacks.get(0)).isInstanceOf(UniversalRulePack.class);
+            });
+  }
+
+  @Test
   void disabledRulesAlsoFilterCustomRules() {
     contextRunner
         .withPropertyValues(
@@ -158,6 +212,30 @@ class SpringPrismAutoConfigurationTest {
             });
   }
 
+  @Test
+  void userProvidedVaultBeanOverridesStarterDefault() {
+    contextRunner
+        .withUserConfiguration(CustomVaultConfiguration.class)
+        .run(
+            context -> {
+              assertThat(context).hasSingleBean(PrismVault.class);
+              assertThat(context.getBean(PrismVault.class))
+                  .isSameAs(context.getBean("customPrismVault"));
+            });
+  }
+
+  @Test
+  void userProvidedRulePackBeanOverridesResolvedDefaults() {
+    contextRunner
+        .withUserConfiguration(CustomRulePackConfiguration.class)
+        .run(
+            context -> {
+              List<PrismRulePack> rulePacks = getRulePacks(context);
+              assertThat(rulePacks).hasSize(1);
+              assertThat(rulePacks.get(0).getName()).isEqualTo("CUSTOM_OVERRIDE");
+            });
+  }
+
   @SuppressWarnings("unchecked")
   private static List<PrismRulePack> getRulePacks(
       org.springframework.context.ApplicationContext context) {
@@ -170,6 +248,35 @@ class SpringPrismAutoConfigurationTest {
     @Bean
     StringRedisTemplate stringRedisTemplate() {
       return mock(StringRedisTemplate.class);
+    }
+  }
+
+  @Configuration(proxyBeanMethods = false)
+  static class CustomVaultConfiguration {
+
+    @Bean("customPrismVault")
+    PrismVault customPrismVault() {
+      return mock(PrismVault.class);
+    }
+  }
+
+  @Configuration(proxyBeanMethods = false)
+  static class CustomRulePackConfiguration {
+
+    @Bean("springPrismRulePacks")
+    List<PrismRulePack> springPrismRulePacks() {
+      return List.of(
+          new PrismRulePack() {
+            @Override
+            public String getName() {
+              return "CUSTOM_OVERRIDE";
+            }
+
+            @Override
+            public List<io.github.catalin87.prism.core.PiiDetector> getDetectors() {
+              return List.of();
+            }
+          });
     }
   }
 }

--- a/website/docs/configuration.md
+++ b/website/docs/configuration.md
@@ -1,6 +1,6 @@
 # Configuration Guide
 
-Spring Prism is configured using standard Spring Boot property files (e.g., `application.yml`).
+Spring Prism is configured using standard Spring Boot property files such as `application.yml`.
 
 ## Configuration Properties
 
@@ -8,30 +8,54 @@ Spring Prism is configured using standard Spring Boot property files (e.g., `app
 |---|---|---|
 | `spring.prism.enabled` | `true` | Globally enable or disable Spring Prism. |
 | `spring.prism.security-strict-mode` | `false` | If true, any failure in detection or vaulting will result in a hard failure (Fail Closed). |
-| `spring.prism.security-salt` | (random) | The salt used for deterministic HMAC signature calculation. This value MUST be kept secret. |
-| `spring.prism.vault-ttl-seconds` | `3600` | The Time-to-Live for PII in the vault. |
-| `spring.prism.rule-pack` | `UNIVERSAL` | The active rule set: `UNIVERSAL` or `EUROPE`. |
+| `spring.prism.app-secret` | `spring-prism-change-me` | The HMAC secret used to sign Prism tokens. Override this in every real deployment. |
+| `spring.prism.ttl` | `30m` | The time-to-live for vault entries. Invalid values fall back to the starter default. |
+| `spring.prism.locales` | `UNIVERSAL` | The active locale set. Common values include `UNIVERSAL`, `EU`, `RO`, `PL`, `DE`, `GB`, `EN`, and `US`. |
+| `spring.prism.disabled-rules` | empty | Entity types to suppress from the resolved rule packs, such as `EMAIL` or `SSN`. |
+| `spring.prism.custom-rules[n].name` | empty | Entity type name for a property-backed custom regex detector. |
+| `spring.prism.custom-rules[n].pattern` | empty | Regex pattern for a property-backed custom regex detector. Blank custom rules are ignored. |
 
-## Spring AI Integration
+## Starter-First Setup
 
-To use Spring Prism with your `ChatClient`, use the `PrismChatClientAdvisor`:
+Add the starter dependency:
 
-```java
-ChatClient chatClient = ChatClient.builder(chatModel)
-    .defaultAdvisors(
-        new PrismChatClientAdvisor(List.of(rulePack), prismVault, ObservationRegistry.NOOP))
-    .build();
-
-String response = chatClient.prompt()
-    .user("My email is user@corp.local")
-    .call()
-    .content();
+```xml
+<dependency>
+  <groupId>io.github.catalin87.prism</groupId>
+  <artifactId>prism-spring-boot-starter</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+</dependency>
 ```
 
-The underlying text sent to the LLM will be:
+Then configure the starter:
+
+```yaml
+spring:
+  prism:
+    app-secret: ${PRISM_APP_SECRET}
+    security-strict-mode: false
+    ttl: 30m
+    locales: EU,EN
+    disabled-rules: SSN
+    custom-rules:
+      - name: INTERNAL_ID
+        pattern: "ID-\\d{5}"
+```
+
+The starter auto-configures:
+- the active `PrismRulePack` list
+- the `PrismVault`
+- the `PrismChatClientAdvisor`
+- the runtime metrics endpoint at `/actuator/prism`
+
+When a `StringRedisTemplate` bean is present, the starter switches to the Redis-backed vault automatically. Otherwise it keeps the default in-memory vault.
+
+## Spring AI Runtime Behavior
+
+Once configured, Prism sanitizes the outbound chat content before dispatching it to the LLM and restores Prism tokens on the way back. The underlying text sent to the model will look like:
 
 ```text
 My email is <PRISM_EMAIL_h8a2...]
 ```
 
-But the `response` string returned to the `chatClient` will have the original email restored.
+The response returned to the application has the original values restored transparently.


### PR DESCRIPTION
## Summary
- add starter-wide enable switch and safer property fallbacks
- harden auto-configuration secret/ttl handling and default vault behavior
- expand starter tests for disablement, overrides, invalid values, and custom-rule filtering
- update the public configuration guide to the starter-first setup path

## Verification
- mvn -Dmaven.repo.local=/tmp/spring-prism-m2 -pl prism-spring-boot-starter -am verify