### PR TITLE
feat: harden redis vault behavior

### DIFF
--- a/prism-spring-boot-starter/src/main/java/io/github/catalin87/prism/boot/autoconfigure/RedisPrismVault.java
+++ b/prism-spring-boot-starter/src/main/java/io/github/catalin87/prism/boot/autoconfigure/RedisPrismVault.java
@@ -28,6 +28,8 @@ import org.springframework.data.redis.core.StringRedisTemplate;
 /** Redis-backed {@link PrismVault} implementation for multi-node deployments. */
 final class RedisPrismVault implements PrismVault {
 
+  private static final Duration MINIMUM_TTL = Duration.ofSeconds(1);
+
   private final StringRedisTemplate redisTemplate;
   private final TokenGenerator tokenGenerator;
   private final byte[] secretKey;
@@ -41,7 +43,7 @@ final class RedisPrismVault implements PrismVault {
     this.redisTemplate = redisTemplate;
     this.tokenGenerator = tokenGenerator;
     this.secretKey = secretKey;
-    this.ttl = ttl;
+    this.ttl = ttl.isZero() || ttl.isNegative() ? MINIMUM_TTL : ttl;
   }
 
   @Override
@@ -54,6 +56,10 @@ final class RedisPrismVault implements PrismVault {
 
   @Override
   public @Nullable String detokenize(@NonNull String tokenKey) {
+    if (!isPrismToken(tokenKey)) {
+      return null;
+    }
+
     String originalValue = redisTemplate.opsForValue().get(tokenKey);
     if (originalValue == null) {
       return null;
@@ -62,11 +68,15 @@ final class RedisPrismVault implements PrismVault {
     PiiCandidate verificationCandidate =
         new PiiCandidate(originalValue, 0, originalValue.length(), extractLabel(tokenKey));
     PrismToken expected = tokenGenerator.generate(verificationCandidate, secretKey);
-    return expected.key().equals(tokenKey) ? originalValue : null;
+    if (!expected.key().equals(tokenKey)) {
+      redisTemplate.delete(tokenKey);
+      return null;
+    }
+    return originalValue;
   }
 
   private String extractLabel(String tokenKey) {
-    if (!tokenKey.startsWith("<PRISM_") || !tokenKey.endsWith(">")) {
+    if (!isPrismToken(tokenKey)) {
       return "UNKNOWN";
     }
     String inner = tokenKey.substring(1, tokenKey.length() - 1);
@@ -76,5 +86,9 @@ final class RedisPrismVault implements PrismVault {
       return "UNKNOWN";
     }
     return inner.substring(firstUnderscore + 1, lastUnderscore).toUpperCase(Locale.ROOT);
+  }
+
+  private boolean isPrismToken(String tokenKey) {
+    return tokenKey.startsWith("<PRISM_") && tokenKey.endsWith(">");
   }
 }

--- a/prism-spring-boot-starter/src/test/java/io/github/catalin87/prism/boot/autoconfigure/RedisPrismVaultTest.java
+++ b/prism-spring-boot-starter/src/test/java/io/github/catalin87/prism/boot/autoconfigure/RedisPrismVaultTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2026 Catalin Dordea and Spring Prism Contributors
+ *
+ * Licensed under the EUPL, Version 1.2 or later (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and
+ * limitations under the Licence.
+ */
+package io.github.catalin87.prism.boot.autoconfigure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.github.catalin87.prism.core.PrismToken;
+import io.github.catalin87.prism.core.token.HmacSha256TokenGenerator;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+/** Focused tests for Redis-backed Prism vault behavior. */
+class RedisPrismVaultTest {
+
+  private final StringRedisTemplate redisTemplate = mock(StringRedisTemplate.class);
+
+  @SuppressWarnings("unchecked")
+  private final ValueOperations<String, String> valueOperations = mock(ValueOperations.class);
+
+  private final byte[] secretKey = "redis-secret".getBytes(StandardCharsets.UTF_8);
+
+  RedisPrismVaultTest() {
+    when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+  }
+
+  @Test
+  void tokenizeStoresValueUsingConfiguredTtl() {
+    RedisPrismVault vault =
+        new RedisPrismVault(
+            redisTemplate, new HmacSha256TokenGenerator(), secretKey, Duration.ofMinutes(5));
+
+    PrismToken token = vault.tokenize("user@corp.local", "EMAIL");
+
+    verify(valueOperations).set(token.key(), "user@corp.local", Duration.ofMinutes(5));
+  }
+
+  @Test
+  void invalidTtlFallsBackToOneSecond() {
+    RedisPrismVault vault =
+        new RedisPrismVault(
+            redisTemplate, new HmacSha256TokenGenerator(), secretKey, Duration.ZERO);
+
+    PrismToken token = vault.tokenize("user@corp.local", "EMAIL");
+
+    verify(valueOperations).set(token.key(), "user@corp.local", Duration.ofSeconds(1));
+  }
+
+  @Test
+  void detokenizeRejectsMalformedTokenWithoutRedisLookup() {
+    RedisPrismVault vault =
+        new RedisPrismVault(
+            redisTemplate, new HmacSha256TokenGenerator(), secretKey, Duration.ofMinutes(5));
+
+    assertThat(vault.detokenize("EMAIL_123")).isNull();
+    verify(valueOperations, never()).get(any());
+  }
+
+  @Test
+  void detokenizeRestoresStoredValueWhenSignatureMatches() {
+    RedisPrismVault vault =
+        new RedisPrismVault(
+            redisTemplate, new HmacSha256TokenGenerator(), secretKey, Duration.ofMinutes(5));
+
+    PrismToken token = vault.tokenize("user@corp.local", "EMAIL");
+    when(valueOperations.get(token.key())).thenReturn("user@corp.local");
+
+    assertThat(vault.detokenize(token.key())).isEqualTo("user@corp.local");
+    verify(redisTemplate, never()).delete(token.key());
+  }
+
+  @Test
+  void detokenizeDeletesTamperedRedisValue() {
+    RedisPrismVault vault =
+        new RedisPrismVault(
+            redisTemplate, new HmacSha256TokenGenerator(), secretKey, Duration.ofMinutes(5));
+
+    PrismToken token = vault.tokenize("user@corp.local", "EMAIL");
+    when(valueOperations.get(token.key())).thenReturn("other@corp.local");
+
+    assertThat(vault.detokenize(token.key())).isNull();
+    verify(redisTemplate).delete(eq(token.key()));
+  }
+}

--- a/website/docs/architecture.md
+++ b/website/docs/architecture.md
@@ -19,6 +19,7 @@ The heartbeat of the system.
 The Spring Boot 3 autoconfiguration bridge.
 - **Frameworks**: Spring Boot 3.4+, Micrometer Observation.
 - **Safety**: "Fail Open" by default (standard security practice) with Micrometer error metrics. "Fail Closed" only if `spring.prism.security-strict-mode=true`.
+- **Deployments**: Uses the in-memory `DefaultPrismVault` by default and switches to `RedisPrismVault` automatically when a `StringRedisTemplate` bean is available.
 - **Optional NLP Extensions**: Person-name detection may be wired here or in `prism-spring-ai` through a lazily loaded backend such as Apache OpenNLP, keeping the core zero-dependency.
 
 ## The Request Lifecycle
@@ -33,6 +34,7 @@ The Spring Boot 3 autoconfiguration bridge.
 
 ## Security Controls
 
-- **HMAC Signatures**: Tokens include an HMAC-SHA256 signature calculated with a salt (provided in `spring.prism.security-salt`). This ensures that even if an attacker gains access to the LLM interaction logs, they cannot reverse the tokens without the application's secret key.
-- **TTL Lifecycle**: Tokens in the vault automatically expire after a configurable period (default: 1 hour).
+- **HMAC Signatures**: Tokens include an HMAC-SHA256 signature calculated with `spring.prism.app-secret`. This ensures that even if an attacker gains access to the LLM interaction logs, they cannot reverse the tokens without the application's secret key.
+- **TTL Lifecycle**: Tokens in the vault automatically expire after a configurable period (default: 30 minutes).
+- **Distributed Vault Option**: Redis-backed deployments preserve the same signature validation model as the local vault while allowing multiple application nodes to restore the same Prism token set.
 - **No PII Logging**: Spring Prism emits Micrometer metrics (`gen_ai.prism.redacted.count`) rather than logging sensitive values.


### PR DESCRIPTION
## Summary
- harden Redis vault token validation and malformed-token handling
- normalize invalid Redis TTLs to a safe minimum
- delete tampered Redis entries when signature verification fails
- add focused Redis vault tests and document local vs distributed deployment guidance

## Verification
- mvn -Dmaven.repo.local=/tmp/spring-prism-m2 -pl prism-spring-boot-starter -am verify