### PR TITLE
feat: auto-configure langchain4j wrappers

### DIFF
--- a/prism-spring-boot-starter/pom.xml
+++ b/prism-spring-boot-starter/pom.xml
@@ -19,6 +19,11 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>io.github.catalin87.prism</groupId>
+            <artifactId>prism-langchain4j</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-autoconfigure</artifactId>
         </dependency>

--- a/prism-spring-boot-starter/src/main/java/io/github/catalin87/prism/boot/autoconfigure/PrismRuntimeMetrics.java
+++ b/prism-spring-boot-starter/src/main/java/io/github/catalin87/prism/boot/autoconfigure/PrismRuntimeMetrics.java
@@ -15,14 +15,15 @@
  */
 package io.github.catalin87.prism.boot.autoconfigure;
 
-import io.github.catalin87.prism.spring.ai.advisor.PrismMetricsSink;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 import org.jspecify.annotations.NonNull;
 
 /** In-memory runtime metrics collector for dashboard and actuator-style reads. */
-public class PrismRuntimeMetrics implements PrismMetricsSink {
+public class PrismRuntimeMetrics
+    implements io.github.catalin87.prism.spring.ai.advisor.PrismMetricsSink,
+        io.github.catalin87.prism.langchain4j.PrismMetricsSink {
 
   private final AtomicLong tokenizedCount = new AtomicLong();
   private final AtomicLong detokenizedCount = new AtomicLong();

--- a/prism-spring-boot-starter/src/main/java/io/github/catalin87/prism/boot/autoconfigure/SpringPrismAutoConfiguration.java
+++ b/prism-spring-boot-starter/src/main/java/io/github/catalin87/prism/boot/autoconfigure/SpringPrismAutoConfiguration.java
@@ -33,8 +33,11 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnSingleCandidate;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import org.springframework.data.redis.core.StringRedisTemplate;
 
 /** Auto-configuration entry point for Spring Prism. */
@@ -144,5 +147,50 @@ public class SpringPrismAutoConfiguration {
 
   private static byte[] secretKey(SpringPrismProperties properties) {
     return properties.getAppSecret().getBytes(StandardCharsets.UTF_8);
+  }
+
+  @Configuration(proxyBeanMethods = false)
+  @ConditionalOnClass(name = "dev.langchain4j.model.chat.ChatModel")
+  static class LangChain4jConfiguration {
+
+    @Bean
+    @Primary
+    @ConditionalOnMissingBean(io.github.catalin87.prism.langchain4j.PrismChatModel.class)
+    @ConditionalOnSingleCandidate(dev.langchain4j.model.chat.ChatModel.class)
+    io.github.catalin87.prism.langchain4j.PrismChatModel prismChatModel(
+        dev.langchain4j.model.chat.ChatModel delegateChatModel,
+        @Qualifier("springPrismRulePacks") List<PrismRulePack> springPrismRulePacks,
+        PrismVault prismVault,
+        ObservationRegistry observationRegistry,
+        PrismRuntimeMetrics prismRuntimeMetrics,
+        SpringPrismProperties properties) {
+      return new io.github.catalin87.prism.langchain4j.PrismChatModel(
+          delegateChatModel,
+          springPrismRulePacks,
+          prismVault,
+          observationRegistry,
+          prismRuntimeMetrics,
+          properties.isSecurityStrictMode());
+    }
+
+    @Bean
+    @Primary
+    @ConditionalOnMissingBean(io.github.catalin87.prism.langchain4j.PrismStreamingChatModel.class)
+    @ConditionalOnSingleCandidate(dev.langchain4j.model.chat.StreamingChatModel.class)
+    io.github.catalin87.prism.langchain4j.PrismStreamingChatModel prismStreamingChatModel(
+        dev.langchain4j.model.chat.StreamingChatModel delegateStreamingChatModel,
+        @Qualifier("springPrismRulePacks") List<PrismRulePack> springPrismRulePacks,
+        PrismVault prismVault,
+        ObservationRegistry observationRegistry,
+        PrismRuntimeMetrics prismRuntimeMetrics,
+        SpringPrismProperties properties) {
+      return new io.github.catalin87.prism.langchain4j.PrismStreamingChatModel(
+          delegateStreamingChatModel,
+          springPrismRulePacks,
+          prismVault,
+          observationRegistry,
+          prismRuntimeMetrics,
+          properties.isSecurityStrictMode());
+    }
   }
 }

--- a/prism-spring-boot-starter/src/test/java/io/github/catalin87/prism/boot/autoconfigure/SpringPrismAutoConfigurationTest.java
+++ b/prism-spring-boot-starter/src/test/java/io/github/catalin87/prism/boot/autoconfigure/SpringPrismAutoConfigurationTest.java
@@ -18,12 +18,20 @@ package io.github.catalin87.prism.boot.autoconfigure;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.StreamingChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
 import io.github.catalin87.prism.core.PrismRulePack;
 import io.github.catalin87.prism.core.PrismVault;
 import io.github.catalin87.prism.core.detector.universal.EmailDetector;
 import io.github.catalin87.prism.core.ruleset.EuropeRulePack;
 import io.github.catalin87.prism.core.ruleset.UniversalRulePack;
 import io.github.catalin87.prism.core.vault.DefaultPrismVault;
+import io.github.catalin87.prism.langchain4j.PrismChatModel;
+import io.github.catalin87.prism.langchain4j.PrismStreamingChatModel;
 import io.github.catalin87.prism.spring.ai.advisor.PrismChatClientAdvisor;
 import io.github.catalin87.prism.spring.ai.advisor.PrismMetricsSink;
 import io.micrometer.observation.ObservationRegistry;
@@ -31,6 +39,7 @@ import java.time.Duration;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.FilteredClassLoader;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -236,6 +245,65 @@ class SpringPrismAutoConfigurationTest {
             });
   }
 
+  @Test
+  void singleLangChainChatModelIsWrappedAsPrimaryBean() {
+    contextRunner
+        .withUserConfiguration(LangChainChatModelConfiguration.class)
+        .run(
+            context -> {
+              assertThat(context).hasSingleBean(PrismChatModel.class);
+              assertThat(context.getBean(ChatModel.class)).isInstanceOf(PrismChatModel.class);
+            });
+  }
+
+  @Test
+  void singleLangChainStreamingChatModelIsWrappedAsPrimaryBean() {
+    contextRunner
+        .withUserConfiguration(LangChainStreamingChatModelConfiguration.class)
+        .run(
+            context -> {
+              assertThat(context).hasSingleBean(PrismStreamingChatModel.class);
+              assertThat(context.getBean(StreamingChatModel.class))
+                  .isInstanceOf(PrismStreamingChatModel.class);
+            });
+  }
+
+  @Test
+  void multipleChatModelDelegatesWithoutPrimaryDoNotCreateWrapper() {
+    contextRunner
+        .withUserConfiguration(MultipleLangChainChatModelsConfiguration.class)
+        .run(
+            context -> {
+              assertThat(context).doesNotHaveBean(PrismChatModel.class);
+              assertThat(context.getBeansOfType(ChatModel.class)).hasSize(2);
+            });
+  }
+
+  @Test
+  void filteredLangChainClassesSkipLangChainAutoConfiguration() {
+    contextRunner
+        .withClassLoader(
+            new FilteredClassLoader("dev.langchain4j", "io.github.catalin87.prism.langchain4j"))
+        .run(
+            context -> {
+              assertThat(context).doesNotHaveBean("prismChatModel");
+              assertThat(context).doesNotHaveBean("prismStreamingChatModel");
+            });
+  }
+
+  @Test
+  void runtimeMetricsAlsoBackLangChainMetricsSink() {
+    contextRunner
+        .withUserConfiguration(LangChainChatModelConfiguration.class)
+        .run(
+            context -> {
+              assertThat(context.getBean(PrismRuntimeMetrics.class))
+                  .isSameAs(
+                      context.getBean(
+                          io.github.catalin87.prism.langchain4j.PrismMetricsSink.class));
+            });
+  }
+
   @SuppressWarnings("unchecked")
   private static List<PrismRulePack> getRulePacks(
       org.springframework.context.ApplicationContext context) {
@@ -277,6 +345,52 @@ class SpringPrismAutoConfigurationTest {
               return List.of();
             }
           });
+    }
+  }
+
+  @Configuration(proxyBeanMethods = false)
+  static class LangChainChatModelConfiguration {
+
+    @Bean("delegateChatModel")
+    ChatModel delegateChatModel() {
+      return new EchoChatModel();
+    }
+  }
+
+  @Configuration(proxyBeanMethods = false)
+  static class LangChainStreamingChatModelConfiguration {
+
+    @Bean("delegateStreamingChatModel")
+    StreamingChatModel delegateStreamingChatModel() {
+      return new NoOpStreamingChatModel();
+    }
+  }
+
+  @Configuration(proxyBeanMethods = false)
+  static class MultipleLangChainChatModelsConfiguration {
+
+    @Bean
+    ChatModel firstChatModel() {
+      return new EchoChatModel();
+    }
+
+    @Bean
+    ChatModel secondChatModel() {
+      return new EchoChatModel();
+    }
+  }
+
+  static class EchoChatModel implements ChatModel {
+    @Override
+    public ChatResponse chat(ChatRequest chatRequest) {
+      return ChatResponse.builder().aiMessage(AiMessage.from("ok")).build();
+    }
+  }
+
+  static class NoOpStreamingChatModel implements StreamingChatModel {
+    @Override
+    public void chat(ChatRequest chatRequest, StreamingChatResponseHandler handler) {
+      handler.onCompleteResponse(ChatResponse.builder().aiMessage(AiMessage.from("ok")).build());
     }
   }
 }

--- a/website/docs/architecture.md
+++ b/website/docs/architecture.md
@@ -32,6 +32,7 @@ The Spring Boot 3 autoconfiguration bridge.
 - **Frameworks**: Spring Boot 3.4+, Micrometer Observation.
 - **Safety**: "Fail Open" by default (standard security practice) with Micrometer error metrics. "Fail Closed" only if `spring.prism.security-strict-mode=true`.
 - **Deployments**: Uses the in-memory `DefaultPrismVault` by default and switches to `RedisPrismVault` automatically when a `StringRedisTemplate` bean is available.
+- **Integrations**: Publishes `PrismChatClientAdvisor` for Spring AI and primary LangChain4j wrappers when delegate chat beans are present.
 - **Optional NLP Extensions**: Person-name detection may be wired here or in `prism-spring-ai` through a lazily loaded backend such as Apache OpenNLP, keeping the core zero-dependency.
 
 ## The Request Lifecycle

--- a/website/docs/configuration.md
+++ b/website/docs/configuration.md
@@ -46,6 +46,7 @@ The starter auto-configures:
 - the active `PrismRulePack` list
 - the `PrismVault`
 - the `PrismChatClientAdvisor`
+- primary LangChain4j `PrismChatModel` and `PrismStreamingChatModel` wrappers when a single delegate `ChatModel` or `StreamingChatModel` bean is present
 - the runtime metrics endpoint at `/actuator/prism`
 
 When a `StringRedisTemplate` bean is present, the starter switches to the Redis-backed vault automatically. Otherwise it keeps the default in-memory vault.
@@ -59,3 +60,12 @@ My email is <PRISM_EMAIL_h8a2...]
 ```
 
 The response returned to the application has the original values restored transparently.
+
+## LangChain4j Runtime Behavior
+
+If your application already defines a single LangChain4j `ChatModel` bean, the starter publishes a
+primary `PrismChatModel` wrapper around it. The same pattern applies to a single
+`StreamingChatModel` bean, which is wrapped as a primary `PrismStreamingChatModel`.
+
+This keeps your original delegate bean available while making the Prism-protected wrapper the
+default injection target for application code.


### PR DESCRIPTION
## Summary
- add starter-managed LangChain4j wrappers for single candidate ChatModel and StreamingChatModel delegates
- reuse the shared runtime metrics collector across Spring AI and LangChain4j integrations
- document the new starter behavior in the architecture and configuration docs

## Testing
- mvn -Dmaven.repo.local=/tmp/spring-prism-m2 -pl prism-spring-boot-starter -am verify
