### PR TITLE
feat: add runnable examples and docs sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,27 +48,54 @@ sequenceDiagram
 
 ## 🚀 Quick Start Snippet
 
-Inject Spring Prism onto your Spring AI `ChatClient` using the current advisor integration:
+Use the starter-first path in your Spring Boot app:
 
 ```java
 @Configuration
 public class AiConfiguration {
 
     @Bean
-    public ChatClient protectedChatClient(
-            ChatClient.Builder builder,
-            PrismRulePack europeRulePack,
-            PrismVault memoryVault) {
-
-        // Refract the data transparently into the Vault, and Restore seamlessly on return!
-        return builder
-            .defaultAdvisors(
-                new PrismChatClientAdvisor(
-                    List.of(europeRulePack), memoryVault, ObservationRegistry.NOOP))
-            .build();
+    ChatClient protectedChatClient(ChatClient.Builder builder) {
+        return builder.build();
     }
 }
 ```
+
+```yaml
+spring:
+  prism:
+    enabled: true
+    app-secret: change-me
+    locales: UNIVERSAL
+```
+
+For manual wiring, advanced rule-pack selection, and both integration paths, start with the
+example apps under `prism-examples/` and the docs in `website/docs/`.
+
+## ✅ Compatibility
+
+| Surface | Version |
+| --- | --- |
+| Java | `21` |
+| Spring Boot | `3.4.x` |
+| Spring AI | `1.0.0-M5` |
+| LangChain4j | `1.0.1` |
+
+## 🧪 Runnable Examples
+
+Spring Prism now ships with two minimal sample apps under `prism-examples/`:
+
+- `spring-ai-example`: starter + Spring AI `ChatClient`
+- `langchain4j-example`: starter + LangChain4j `ChatModel`
+
+Each example boots with Java 21, avoids real API keys, and includes an integration test proving
+that the delegate sees tokenized content while the caller receives restored PII.
+
+## 🔁 Upgrade Notes
+
+Use the starter-first path as the default integration model and see `website/docs/migration-guide.md`
+for the current Spring AI constructor shape, LangChain4j wrapper behavior, and Redis auto-selection
+defaults.
 
 ---
 
@@ -90,6 +117,7 @@ Spring Prism executes strict isolation through a robust Maven multi-module archi
 | `prism-spring-ai` | Spring AI advisor integration for synchronous and streaming chat interception. |
 | `prism-langchain4j` | LangChain4j `ChatModel` and `StreamingChatModel` decorators for tokenization and restoration. |
 | `prism-spring-boot-starter` | Instantly initializes Spring AI auto-configurations and exposes cleanly configurable `application.yml` localization boundaries. |
+| `prism-examples` | Runnable Spring Boot examples for the Spring AI and LangChain4j integration paths. |
 | `prism-dashboard` | An optional, self-hosted visual interface rendering Micrometer usage statistics on exactly what PII parameters were prevented from escaping to the LLM. |
 
 ## 📜 Governance & Licensing

--- a/prism-examples/langchain4j-example/pom.xml
+++ b/prism-examples/langchain4j-example/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.github.catalin87.prism</groupId>
+        <artifactId>prism-examples</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>langchain4j-example</artifactId>
+    <name>Spring Prism LangChain4j Example</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.github.catalin87.prism</groupId>
+            <artifactId>prism-spring-boot-starter</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-core</artifactId>
+            <version>${langchain4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${spring-boot.version}</version>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/prism-examples/langchain4j-example/src/main/java/io/github/catalin87/prism/examples/langchain4j/LangChain4jExampleApplication.java
+++ b/prism-examples/langchain4j-example/src/main/java/io/github/catalin87/prism/examples/langchain4j/LangChain4jExampleApplication.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2026 Catalin Dordea and Spring Prism Contributors
+ *
+ * Licensed under the EUPL, Version 1.2 or later (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and
+ * limitations under the Licence.
+ */
+package io.github.catalin87.prism.examples.langchain4j;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/** Runnable Spring Boot sample showing Spring Prism with LangChain4j. */
+@SpringBootApplication
+public class LangChain4jExampleApplication {
+
+  public static void main(String[] args) {
+    SpringApplication.run(LangChain4jExampleApplication.class, args);
+  }
+}

--- a/prism-examples/langchain4j-example/src/main/java/io/github/catalin87/prism/examples/langchain4j/LangChain4jExampleConfig.java
+++ b/prism-examples/langchain4j-example/src/main/java/io/github/catalin87/prism/examples/langchain4j/LangChain4jExampleConfig.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2026 Catalin Dordea and Spring Prism Contributors
+ *
+ * Licensed under the EUPL, Version 1.2 or later (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and
+ * limitations under the Licence.
+ */
+package io.github.catalin87.prism.examples.langchain4j;
+
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/** Beans for the LangChain4j example application. */
+@Configuration(proxyBeanMethods = false)
+class LangChain4jExampleConfig {
+
+  @Bean("delegateChatModel")
+  RecordingLangChainChatModel delegateChatModel() {
+    return new RecordingLangChainChatModel();
+  }
+
+  static final class RecordingLangChainChatModel implements ChatModel {
+    private final List<ChatRequest> requests = new CopyOnWriteArrayList<>();
+
+    @Override
+    public ChatResponse chat(ChatRequest chatRequest) {
+      requests.add(chatRequest);
+      return ChatResponse.builder()
+          .aiMessage(
+              AiMessage.from("LangChain4j reply: " + chatRequest.messages().getLast().toString()))
+          .build();
+    }
+
+    List<ChatRequest> requests() {
+      return List.copyOf(requests);
+    }
+  }
+}

--- a/prism-examples/langchain4j-example/src/main/java/io/github/catalin87/prism/examples/langchain4j/LangChain4jExampleController.java
+++ b/prism-examples/langchain4j-example/src/main/java/io/github/catalin87/prism/examples/langchain4j/LangChain4jExampleController.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026 Catalin Dordea and Spring Prism Contributors
+ *
+ * Licensed under the EUPL, Version 1.2 or later (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and
+ * limitations under the Licence.
+ */
+package io.github.catalin87.prism.examples.langchain4j;
+
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.model.chat.ChatModel;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/** HTTP entrypoint for the LangChain4j example. */
+@RestController
+@RequestMapping("/demo/langchain4j")
+class LangChain4jExampleController {
+
+  private final ChatModel chatModel;
+
+  LangChain4jExampleController(ChatModel chatModel) {
+    this.chatModel = chatModel;
+  }
+
+  @GetMapping
+  String demo(@RequestParam("email") String email) {
+    return chatModel.chat(UserMessage.from("Please contact " + email)).aiMessage().text();
+  }
+}

--- a/prism-examples/langchain4j-example/src/main/resources/application.yml
+++ b/prism-examples/langchain4j-example/src/main/resources/application.yml
@@ -1,0 +1,4 @@
+spring:
+  prism:
+    app-secret: example-langchain4j-secret
+    locales: UNIVERSAL

--- a/prism-examples/langchain4j-example/src/test/java/io/github/catalin87/prism/examples/langchain4j/LangChain4jExampleApplicationTest.java
+++ b/prism-examples/langchain4j-example/src/test/java/io/github/catalin87/prism/examples/langchain4j/LangChain4jExampleApplicationTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026 Catalin Dordea and Spring Prism Contributors
+ *
+ * Licensed under the EUPL, Version 1.2 or later (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and
+ * limitations under the Licence.
+ */
+package io.github.catalin87.prism.examples.langchain4j;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.data.message.UserMessage;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalServerPort;
+
+/** Integration tests for the LangChain4j example app. */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class LangChain4jExampleApplicationTest {
+
+  @LocalServerPort private int port;
+
+  @Autowired private TestRestTemplate restTemplate;
+
+  @Autowired private LangChain4jExampleConfig.RecordingLangChainChatModel delegateChatModel;
+
+  @Test
+  void exampleBootsAndRestoresPiiForLangChain4j() {
+    String email = "user@example.com";
+
+    String response =
+        restTemplate.getForObject(
+            "http://localhost:" + port + "/demo/langchain4j?email={email}", String.class, email);
+
+    assertThat(response).contains(email);
+    assertThat(delegateChatModel.requests()).isNotEmpty();
+    UserMessage recorded =
+        (UserMessage) delegateChatModel.requests().getLast().messages().getLast();
+    assertThat(recorded.singleText()).contains("<PRISM_EMAIL_").doesNotContain(email);
+  }
+}

--- a/prism-examples/pom.xml
+++ b/prism-examples/pom.xml
@@ -7,4 +7,10 @@
         <version>1.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>prism-examples</artifactId>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>spring-ai-example</module>
+        <module>langchain4j-example</module>
+    </modules>
 </project>

--- a/prism-examples/spring-ai-example/pom.xml
+++ b/prism-examples/spring-ai-example/pom.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.github.catalin87.prism</groupId>
+        <artifactId>prism-examples</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>spring-ai-example</artifactId>
+    <name>Spring Prism Spring AI Example</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.github.catalin87.prism</groupId>
+            <artifactId>prism-spring-boot-starter</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${spring-boot.version}</version>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/prism-examples/spring-ai-example/src/main/java/io/github/catalin87/prism/examples/springai/SpringAiExampleApplication.java
+++ b/prism-examples/spring-ai-example/src/main/java/io/github/catalin87/prism/examples/springai/SpringAiExampleApplication.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2026 Catalin Dordea and Spring Prism Contributors
+ *
+ * Licensed under the EUPL, Version 1.2 or later (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and
+ * limitations under the Licence.
+ */
+package io.github.catalin87.prism.examples.springai;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/** Runnable Spring Boot sample showing Spring Prism with Spring AI. */
+@SpringBootApplication
+public class SpringAiExampleApplication {
+
+  public static void main(String[] args) {
+    SpringApplication.run(SpringAiExampleApplication.class, args);
+  }
+}

--- a/prism-examples/spring-ai-example/src/main/java/io/github/catalin87/prism/examples/springai/SpringAiExampleConfig.java
+++ b/prism-examples/spring-ai-example/src/main/java/io/github/catalin87/prism/examples/springai/SpringAiExampleConfig.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2026 Catalin Dordea and Spring Prism Contributors
+ *
+ * Licensed under the EUPL, Version 1.2 or later (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and
+ * limitations under the Licence.
+ */
+package io.github.catalin87.prism.examples.springai;
+
+import io.github.catalin87.prism.spring.ai.advisor.PrismChatClientAdvisor;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import org.jspecify.annotations.NonNull;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.Generation;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/** Beans for the Spring AI example application. */
+@Configuration(proxyBeanMethods = false)
+class SpringAiExampleConfig {
+
+  @Bean
+  RecordingSpringAiChatModel recordingSpringAiChatModel() {
+    return new RecordingSpringAiChatModel();
+  }
+
+  @Bean
+  ChatClient exampleChatClient(
+      RecordingSpringAiChatModel recordingSpringAiChatModel,
+      PrismChatClientAdvisor prismChatClientAdvisor) {
+    return ChatClient.builder(recordingSpringAiChatModel)
+        .defaultAdvisors(prismChatClientAdvisor)
+        .build();
+  }
+
+  static final class RecordingSpringAiChatModel implements ChatModel {
+    private final List<String> prompts = new CopyOnWriteArrayList<>();
+
+    @Override
+    public @NonNull ChatResponse call(@NonNull Prompt prompt) {
+      String content = prompt.getContents();
+      prompts.add(content);
+      return new ChatResponse(
+          List.of(new Generation(new AssistantMessage("Spring AI reply: " + content))));
+    }
+
+    List<String> prompts() {
+      return List.copyOf(prompts);
+    }
+  }
+}

--- a/prism-examples/spring-ai-example/src/main/java/io/github/catalin87/prism/examples/springai/SpringAiExampleController.java
+++ b/prism-examples/spring-ai-example/src/main/java/io/github/catalin87/prism/examples/springai/SpringAiExampleController.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026 Catalin Dordea and Spring Prism Contributors
+ *
+ * Licensed under the EUPL, Version 1.2 or later (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and
+ * limitations under the Licence.
+ */
+package io.github.catalin87.prism.examples.springai;
+
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/** HTTP entrypoint for the Spring AI example. */
+@RestController
+@RequestMapping("/demo/spring-ai")
+class SpringAiExampleController {
+
+  private final ChatClient chatClient;
+
+  SpringAiExampleController(ChatClient chatClient) {
+    this.chatClient = chatClient;
+  }
+
+  @GetMapping
+  String demo(@RequestParam("email") String email) {
+    return chatClient.prompt().user("Please contact " + email).call().content();
+  }
+}

--- a/prism-examples/spring-ai-example/src/main/resources/application.yml
+++ b/prism-examples/spring-ai-example/src/main/resources/application.yml
@@ -1,0 +1,4 @@
+spring:
+  prism:
+    app-secret: example-spring-ai-secret
+    locales: UNIVERSAL

--- a/prism-examples/spring-ai-example/src/test/java/io/github/catalin87/prism/examples/springai/SpringAiExampleApplicationTest.java
+++ b/prism-examples/spring-ai-example/src/test/java/io/github/catalin87/prism/examples/springai/SpringAiExampleApplicationTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026 Catalin Dordea and Spring Prism Contributors
+ *
+ * Licensed under the EUPL, Version 1.2 or later (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and
+ * limitations under the Licence.
+ */
+package io.github.catalin87.prism.examples.springai;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalServerPort;
+
+/** Integration tests for the Spring AI example app. */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class SpringAiExampleApplicationTest {
+
+  @LocalServerPort private int port;
+
+  @Autowired private TestRestTemplate restTemplate;
+
+  @Autowired private SpringAiExampleConfig.RecordingSpringAiChatModel recordingSpringAiChatModel;
+
+  @Test
+  void exampleBootsAndRestoresPiiForSpringAi() {
+    String email = "user@example.com";
+
+    String response =
+        restTemplate.getForObject(
+            "http://localhost:" + port + "/demo/spring-ai?email={email}", String.class, email);
+
+    assertThat(response).contains("user@example.com");
+    assertThat(recordingSpringAiChatModel.prompts()).isNotEmpty();
+    assertThat(recordingSpringAiChatModel.prompts().getLast())
+        .contains("<PRISM_EMAIL_")
+        .doesNotContain(email);
+  }
+}

--- a/prism-spring-boot-starter/src/main/java/io/github/catalin87/prism/boot/autoconfigure/SpringPrismAutoConfiguration.java
+++ b/prism-spring-boot-starter/src/main/java/io/github/catalin87/prism/boot/autoconfigure/SpringPrismAutoConfiguration.java
@@ -31,14 +31,12 @@ import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnSingleCandidate;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
-import org.springframework.data.redis.core.StringRedisTemplate;
 
 /** Auto-configuration entry point for Spring Prism. */
 @AutoConfiguration
@@ -72,30 +70,7 @@ public class SpringPrismAutoConfiguration {
 
   @Bean
   @ConditionalOnMissingBean
-  @ConditionalOnBean(StringRedisTemplate.class)
-  PrismVault redisPrismVault(
-      TokenGenerator prismTokenGenerator,
-      SpringPrismProperties properties,
-      StringRedisTemplate stringRedisTemplate) {
-    Duration ttl = properties.getTtl();
-    byte[] secret = secretKey(properties);
-    return new RedisPrismVault(stringRedisTemplate, prismTokenGenerator, secret, ttl);
-  }
-
-  @Bean
-  @ConditionalOnMissingBean
-  @ConditionalOnMissingClass("org.springframework.data.redis.core.StringRedisTemplate")
   PrismVault prismVault(TokenGenerator prismTokenGenerator, SpringPrismProperties properties) {
-    long ttlSeconds = Math.max(1L, properties.getTtl().toSeconds());
-    byte[] secret = secretKey(properties);
-    return new DefaultPrismVault(prismTokenGenerator, secret, ttlSeconds);
-  }
-
-  @Bean
-  @ConditionalOnMissingBean
-  @ConditionalOnClass(StringRedisTemplate.class)
-  PrismVault fallbackPrismVault(
-      TokenGenerator prismTokenGenerator, SpringPrismProperties properties) {
     long ttlSeconds = Math.max(1L, properties.getTtl().toSeconds());
     byte[] secret = secretKey(properties);
     return new DefaultPrismVault(prismTokenGenerator, secret, ttlSeconds);
@@ -191,6 +166,23 @@ public class SpringPrismAutoConfiguration {
           observationRegistry,
           prismRuntimeMetrics,
           properties.isSecurityStrictMode());
+    }
+  }
+
+  @Configuration(proxyBeanMethods = false)
+  @ConditionalOnClass(name = "org.springframework.data.redis.core.StringRedisTemplate")
+  static class RedisConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean
+    @ConditionalOnBean(type = "org.springframework.data.redis.core.StringRedisTemplate")
+    PrismVault redisPrismVault(
+        TokenGenerator prismTokenGenerator,
+        SpringPrismProperties properties,
+        org.springframework.data.redis.core.StringRedisTemplate stringRedisTemplate) {
+      Duration ttl = properties.getTtl();
+      byte[] secret = secretKey(properties);
+      return new RedisPrismVault(stringRedisTemplate, prismTokenGenerator, secret, ttl);
     }
   }
 }

--- a/prism-spring-boot-starter/src/test/java/io/github/catalin87/prism/boot/autoconfigure/SpringPrismAutoConfigurationTest.java
+++ b/prism-spring-boot-starter/src/test/java/io/github/catalin87/prism/boot/autoconfigure/SpringPrismAutoConfigurationTest.java
@@ -158,6 +158,17 @@ class SpringPrismAutoConfigurationTest {
   }
 
   @Test
+  void autoConfigurationStillLoadsWithoutRedisOnClasspath() {
+    contextRunner
+        .withClassLoader(new FilteredClassLoader("org.springframework.data.redis"))
+        .run(
+            context -> {
+              assertThat(context).hasSingleBean(PrismVault.class);
+              assertThat(context.getBean(PrismVault.class)).isInstanceOf(DefaultPrismVault.class);
+            });
+  }
+
+  @Test
   void metricsControllerExposesRuntimeSnapshot() {
     contextRunner.run(
         context -> {

--- a/website/docs/compatibility.md
+++ b/website/docs/compatibility.md
@@ -1,0 +1,24 @@
+# Compatibility Matrix
+
+Spring Prism currently validates the following production-facing baseline:
+
+| Surface | Supported baseline |
+| --- | --- |
+| Java | `21` |
+| Spring Boot | `3.4.x` |
+| Spring AI | `1.0.0-M5` |
+| LangChain4j | `1.0.1` |
+
+These versions match the current build and CI matrix. If you move outside this range, treat it as
+untested until the library publishes an updated compatibility statement.
+
+## Module Support
+
+| Module | Status |
+| --- | --- |
+| `prism-core` | Production-ready core engine |
+| `prism-spring-ai` | Supported |
+| `prism-langchain4j` | Supported |
+| `prism-spring-boot-starter` | Supported |
+| `prism-dashboard` | Deferred |
+| MCP support | Deferred |

--- a/website/docs/intro.md
+++ b/website/docs/intro.md
@@ -29,6 +29,11 @@ To include Spring Prism in your project, add the following dependency (once publ
 </dependency>
 ```
 
+Then use the runnable examples in `prism-examples/` as the canonical onboarding path:
+
+- `spring-ai-example`
+- `langchain4j-example`
+
 ## How it Works
 
 1. **Scan**: Intercepts the prompt sent to the LLM.

--- a/website/docs/migration-guide.md
+++ b/website/docs/migration-guide.md
@@ -1,0 +1,47 @@
+# Migration Guide
+
+This guide summarizes the externally visible changes made while closing phases 1-3.
+
+## Current Integration Shape
+
+- Prefer the Spring Boot starter as the default integration entrypoint.
+- Spring AI support is exposed through `PrismChatClientAdvisor`.
+- LangChain4j support is exposed through `PrismChatModel` and `PrismStreamingChatModel`.
+
+## Starter Defaults
+
+- `spring.prism.enabled` defaults to `true`.
+- `spring.prism.ttl` defaults to `30m`.
+- `spring.prism.locales` defaults to `UNIVERSAL`.
+- blank or missing `spring.prism.app-secret` falls back to `spring-prism-change-me`, but real
+  deployments must override it.
+
+## Spring AI
+
+- The current Spring AI path is starter-first.
+- If you wire manually, use the current constructor shape:
+
+```java
+new PrismChatClientAdvisor(List.of(rulePack), prismVault, ObservationRegistry.NOOP)
+```
+
+## LangChain4j
+
+- LangChain4j support now ships as a first-class module.
+- If the starter sees a single delegate `ChatModel` bean, it publishes a primary
+  `PrismChatModel` wrapper.
+- If the starter sees a single delegate `StreamingChatModel` bean, it publishes a primary
+  `PrismStreamingChatModel` wrapper.
+
+## Redis Vault Selection
+
+- The starter keeps `DefaultPrismVault` by default.
+- If a `StringRedisTemplate` bean is present, the starter switches to `RedisPrismVault`
+  automatically.
+
+## Recommended Upgrade Path
+
+1. Move to `prism-spring-boot-starter` if you were wiring components manually.
+2. Set an explicit `spring.prism.app-secret`.
+3. Verify your active locales and disabled rules explicitly in configuration.
+4. For LangChain4j applications, expose one delegate chat bean and let the starter wrap it.


### PR DESCRIPTION
## Summary
- add runnable Spring AI and LangChain4j example apps under prism-examples
- sync README and Docusaurus docs with compatibility, onboarding, and migration guidance
- harden starter Redis auto-configuration so apps without spring-data-redis still boot cleanly

## Testing
- mvn -Dmaven.repo.local=/tmp/spring-prism-m2 -pl prism-spring-boot-starter,prism-examples/spring-ai-example,prism-examples/langchain4j-example -am test -DskipITs
- mvn -Dmaven.repo.local=/tmp/spring-prism-m2 -pl prism-examples/langchain4j-example -am test -DskipITs