### PR TITLE
docs: add release readiness guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,24 @@ Use the starter-first path as the default integration model and see `website/doc
 for the current Spring AI constructor shape, LangChain4j wrapper behavior, and Redis auto-selection
 defaults.
 
+## 📦 Release Readiness
+
+The current supported library surface is:
+
+- `prism-core`
+- `prism-spring-ai`
+- `prism-langchain4j`
+- `prism-spring-boot-starter`
+- `prism-examples`
+
+Deferred surfaces:
+
+- `prism-dashboard`
+- MCP support
+
+See `website/docs/release-readiness.md` for the current verification baseline, release-profile
+expectations, and the shipped-vs-deferred support boundary.
+
 ---
 
 ## 🔒 Security Posture & Architecture Guarantee

--- a/website/docs/release-readiness.md
+++ b/website/docs/release-readiness.md
@@ -1,0 +1,58 @@
+# Release Readiness
+
+Spring Prism currently ships a production-ready library baseline for the privacy firewall itself.
+
+## Shipped Today
+
+The following modules are part of the supported library surface:
+
+| Module | Role | Status |
+| --- | --- | --- |
+| `prism-core` | Zero-dependency detectors, rule packs, vault, tokenization, streaming buffer | Supported |
+| `prism-spring-ai` | Spring AI advisor integration for synchronous and streaming chat flows | Supported |
+| `prism-langchain4j` | LangChain4j `ChatModel` and `StreamingChatModel` wrappers | Supported |
+| `prism-spring-boot-starter` | Spring Boot properties, auto-configuration, Redis selection, metrics surface | Supported |
+| `prism-examples` | Runnable Spring Boot sample apps for both supported integrations | Supported |
+
+## Deferred
+
+The following surfaces are intentionally outside the current release boundary:
+
+| Surface | Status |
+| --- | --- |
+| `prism-dashboard` | Deferred |
+| MCP support | Deferred |
+| Optional NLP/person-name detection | Deferred |
+
+## What We Validate
+
+The current verification baseline covers:
+
+- full root `mvn verify`
+- `prism-core` JaCoCo coverage gate at `90%+`
+- Spotless, Checkstyle, and Enforcer policies across the reactor
+- WireMock-backed Spring AI integration tests
+- LangChain4j wrapper tests
+- starter auto-configuration tests, including Redis-absent startup safety
+- runnable Spring AI and LangChain4j example applications that boot and prove redaction/restoration
+
+## Release Profile
+
+The Maven `release` profile is configured to attach:
+
+- source jars
+- javadoc jars
+- GPG signing
+- Central publishing metadata
+
+For local release-profile verification without publishing, use:
+
+```bash
+mvn -Prelease -Dgpg.skip=true -DskipTests package
+```
+
+## Notes
+
+- `spring.prism.app-secret` must be overridden in every real deployment.
+- Fail-open remains the default behavior; strict mode is opt-in through `spring.prism.security-strict-mode=true`.
+- Redis is the supported distributed vault path for this release boundary.


### PR DESCRIPTION
## Summary
- add a release-readiness guide that states the shipped vs deferred support boundary
- document the current verification baseline and release profile expectations
- confirm the library branch with a full root verify and release-profile package run

## Testing
- mvn -Dmaven.repo.local=/tmp/spring-prism-m2 verify
- mvn -Dmaven.repo.local=/tmp/spring-prism-m2 -Prelease -Dgpg.skip=true -DskipTests package