### PR TITLE
feat: harden prism performance paths

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,7 @@
         <module>prism-spring-ai</module>
         <module>prism-langchain4j</module>
         <module>prism-spring-boot-starter</module>
+        <module>prism-benchmarks</module>
         <module>prism-dashboard</module>
         <module>prism-examples</module>
     </modules>
@@ -56,6 +57,7 @@
         <spring-boot.version>3.4.13</spring-boot.version>
         <spring-ai.version>1.0.0-M5</spring-ai.version>
         <langchain4j.version>1.0.1</langchain4j.version>
+        <jmh.version>1.37</jmh.version>
         <tomcat.version>10.1.52</tomcat.version>
         <log4j2.version>2.25.3</log4j2.version>
         <jspecify.version>1.0.0</jspecify.version>

--- a/prism-benchmarks/pom.xml
+++ b/prism-benchmarks/pom.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.github.catalin87.prism</groupId>
+        <artifactId>prism-parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>prism-benchmarks</artifactId>
+    <name>Prism Benchmarks</name>
+    <description>JMH microbenchmarks for detector, vault, streaming, and Redis-backed paths.</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.github.catalin87.prism</groupId>
+            <artifactId>prism-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.github.catalin87.prism</groupId>
+            <artifactId>prism-spring-boot-starter</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.data</groupId>
+            <artifactId>spring-data-redis</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-core</artifactId>
+            <version>${jmh.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-generator-annprocess</artifactId>
+            <version>${jmh.version}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.13.0</version>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.openjdk.jmh</groupId>
+                            <artifactId>jmh-generator-annprocess</artifactId>
+                            <version>${jmh.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.6.0</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <finalName>benchmarks</finalName>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>org.openjdk.jmh.Main</mainClass>
+                                </transformer>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                            </transformers>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/prism-benchmarks/src/main/java/io/github/catalin87/prism/benchmarks/DetectorBenchmark.java
+++ b/prism-benchmarks/src/main/java/io/github/catalin87/prism/benchmarks/DetectorBenchmark.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2026 Catalin Dordea and Spring Prism Contributors
+ *
+ * Licensed under the EUPL, Version 1.2 or later (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and
+ * limitations under the Licence.
+ */
+package io.github.catalin87.prism.benchmarks;
+
+import io.github.catalin87.prism.core.PiiDetector;
+import io.github.catalin87.prism.core.ruleset.UniversalRulePack;
+import java.util.List;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+
+/** Benchmarks the detector-heavy universal rule pack paths used during outbound scans. */
+@State(Scope.Benchmark)
+public class DetectorBenchmark {
+
+  private final List<PiiDetector> detectors = new UniversalRulePack().getDetectors();
+  private final String mixedPiiText =
+      "Reach user@example.com, card 4111 1111 1111 1111, phone +40 712 345 678, "
+          + "SSN 123-45-6789 and IP 2001:db8::1.";
+  private final String cleanText =
+      "A prompt about weather, architecture, and release notes with no sensitive fields.";
+
+  /** Measures full universal-pack detection cost on text containing several PII categories. */
+  @Benchmark
+  public int detectMixedUniversalPii() {
+    int matches = 0;
+    for (PiiDetector detector : detectors) {
+      matches += detector.detect(mixedPiiText).size();
+    }
+    return matches;
+  }
+
+  /** Measures the cheap skip path when detector heuristics reject obviously clean text. */
+  @Benchmark
+  public int skipCleanTextViaFastPaths() {
+    int scans = 0;
+    for (PiiDetector detector : detectors) {
+      if (detector.mayMatch(cleanText)) {
+        scans += detector.detect(cleanText).size();
+      }
+    }
+    return scans;
+  }
+}

--- a/prism-benchmarks/src/main/java/io/github/catalin87/prism/benchmarks/StreamingBufferBenchmark.java
+++ b/prism-benchmarks/src/main/java/io/github/catalin87/prism/benchmarks/StreamingBufferBenchmark.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026 Catalin Dordea and Spring Prism Contributors
+ *
+ * Licensed under the EUPL, Version 1.2 or later (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and
+ * limitations under the Licence.
+ */
+package io.github.catalin87.prism.benchmarks;
+
+import io.github.catalin87.prism.core.vault.StreamingBuffer;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+
+/** Benchmarks fragmented Prism token buffering during streaming response restoration. */
+@State(Scope.Thread)
+public class StreamingBufferBenchmark {
+
+  private final String[] chunks = {"message ", "<PRISM_EM", "AIL_ABC123", "> done"};
+
+  /** Measures fragmented token buffering for a representative streaming response sequence. */
+  @Benchmark
+  public String processFragmentedToken() {
+    StreamingBuffer buffer = new StreamingBuffer();
+    StringBuilder output = new StringBuilder();
+    for (String chunk : chunks) {
+      output.append(buffer.processChunk(chunk));
+    }
+    output.append(buffer.flush());
+    return output.toString();
+  }
+}

--- a/prism-benchmarks/src/main/java/io/github/catalin87/prism/benchmarks/VaultBenchmark.java
+++ b/prism-benchmarks/src/main/java/io/github/catalin87/prism/benchmarks/VaultBenchmark.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2026 Catalin Dordea and Spring Prism Contributors
+ *
+ * Licensed under the EUPL, Version 1.2 or later (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and
+ * limitations under the Licence.
+ */
+package io.github.catalin87.prism.benchmarks;
+
+import io.github.catalin87.prism.core.PrismToken;
+import io.github.catalin87.prism.core.TokenGenerator;
+import io.github.catalin87.prism.core.token.HmacSha256TokenGenerator;
+import io.github.catalin87.prism.core.vault.DefaultPrismVault;
+import java.nio.charset.StandardCharsets;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+/** Measures in-memory vault tokenization and restoration throughput. */
+@State(Scope.Benchmark)
+public class VaultBenchmark {
+
+  private DefaultPrismVault vault;
+  private String tokenKey;
+
+  /** Prepares a stable token for repeated in-memory detokenization measurements. */
+  @Setup
+  public void setUp() {
+    TokenGenerator generator = new HmacSha256TokenGenerator();
+    vault =
+        new DefaultPrismVault(
+            generator, "benchmark-secret-material-32bytes".getBytes(StandardCharsets.UTF_8), 3600L);
+    PrismToken token = vault.tokenize("user@example.com", "EMAIL");
+    tokenKey = token.key();
+  }
+
+  /** Measures token creation throughput in the default in-memory vault. */
+  @Benchmark
+  public PrismToken tokenizeEmail() {
+    return vault.tokenize("user@example.com", "EMAIL");
+  }
+
+  /** Measures token restoration throughput in the default in-memory vault. */
+  @Benchmark
+  public String detokenizeEmail() {
+    return vault.detokenize(tokenKey);
+  }
+}

--- a/prism-benchmarks/src/main/java/io/github/catalin87/prism/boot/autoconfigure/RedisVaultBenchmark.java
+++ b/prism-benchmarks/src/main/java/io/github/catalin87/prism/boot/autoconfigure/RedisVaultBenchmark.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2026 Catalin Dordea and Spring Prism Contributors
+ *
+ * Licensed under the EUPL, Version 1.2 or later (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and
+ * limitations under the Licence.
+ */
+package io.github.catalin87.prism.boot.autoconfigure;
+
+import io.github.catalin87.prism.core.PrismToken;
+import io.github.catalin87.prism.core.token.HmacSha256TokenGenerator;
+import java.lang.reflect.Proxy;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+/**
+ * Benchmarks the Redis-backed vault code path using an in-memory {@link StringRedisTemplate}
+ * substitute so normal builds do not require a running Redis server.
+ */
+@State(Scope.Benchmark)
+public class RedisVaultBenchmark {
+
+  private RedisPrismVault vault;
+  private String tokenKey;
+
+  /** Prepares a Redis-backed vault path using the in-memory benchmark template. */
+  @Setup
+  public void setUp() {
+    InMemoryStringRedisTemplate redisTemplate = new InMemoryStringRedisTemplate();
+    vault =
+        new RedisPrismVault(
+            redisTemplate,
+            new HmacSha256TokenGenerator(),
+            "redis-benchmark-secret-material".getBytes(StandardCharsets.UTF_8),
+            Duration.ofMinutes(30));
+    PrismToken token = vault.tokenize("user@example.com", "EMAIL");
+    tokenKey = token.key();
+  }
+
+  @Benchmark
+  public PrismToken tokenizeEmail() {
+    return vault.tokenize("user@example.com", "EMAIL");
+  }
+
+  @Benchmark
+  public String detokenizeEmail() {
+    return vault.detokenize(tokenKey);
+  }
+
+  private static final class InMemoryStringRedisTemplate extends StringRedisTemplate {
+
+    private final Map<String, String> store = new ConcurrentHashMap<>();
+    private final ValueOperations<String, String> valueOperations = createValueOperations();
+
+    @SuppressWarnings("unchecked")
+    private ValueOperations<String, String> createValueOperations() {
+      return (ValueOperations<String, String>)
+          Proxy.newProxyInstance(
+              ValueOperations.class.getClassLoader(),
+              new Class<?>[] {ValueOperations.class},
+              (proxy, method, args) -> {
+                String methodName = method.getName();
+                if ("set".equals(methodName)) {
+                  store.put((String) args[0], (String) args[1]);
+                  return null;
+                }
+                if ("get".equals(methodName)) {
+                  return store.get(args[0]);
+                }
+                throw new UnsupportedOperationException(methodName);
+              });
+    }
+
+    @Override
+    public ValueOperations<String, String> opsForValue() {
+      return valueOperations;
+    }
+
+    @Override
+    public Boolean delete(String key) {
+      return store.remove(key) != null;
+    }
+  }
+}

--- a/prism-core/src/main/java/io/github/catalin87/prism/core/PiiDetector.java
+++ b/prism-core/src/main/java/io/github/catalin87/prism/core/PiiDetector.java
@@ -25,6 +25,17 @@ import org.jspecify.annotations.NonNull;
 public interface PiiDetector {
 
   /**
+   * Cheap pre-check used to skip expensive regex or checksum work when the input cannot possibly
+   * contain this detector's target data.
+   *
+   * @param text The source text to analyze.
+   * @return {@code true} when a full scan is worthwhile, otherwise {@code false}.
+   */
+  default boolean mayMatch(@NonNull String text) {
+    return !text.isEmpty();
+  }
+
+  /**
    * Determines the classification descriptor allocated to fragments resolved natively by this
    * framework component.
    *
@@ -40,4 +51,25 @@ public interface PiiDetector {
    * @return A list of {@link PiiCandidate} objects indicating exact locations in the text.
    */
   @NonNull List<PiiCandidate> detect(@NonNull String text);
+
+  /** Returns {@code true} when the text contains at least one decimal digit. */
+  static boolean containsDigit(@NonNull String text) {
+    for (int index = 0; index < text.length(); index++) {
+      if (Character.isDigit(text.charAt(index))) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /** Returns {@code true} when either marker character occurs in the source text. */
+  static boolean containsEither(@NonNull String text, char first, char second) {
+    for (int index = 0; index < text.length(); index++) {
+      char current = text.charAt(index);
+      if (current == first || current == second) {
+        return true;
+      }
+    }
+    return false;
+  }
 }

--- a/prism-core/src/main/java/io/github/catalin87/prism/core/detector/europe/CnpDetector.java
+++ b/prism-core/src/main/java/io/github/catalin87/prism/core/detector/europe/CnpDetector.java
@@ -40,8 +40,13 @@ public class CnpDetector implements PiiDetector {
   }
 
   @Override
+  public boolean mayMatch(@NonNull String input) {
+    return PiiDetector.containsDigit(input);
+  }
+
+  @Override
   public @NonNull List<PiiCandidate> detect(@NonNull String input) {
-    if (input.isEmpty()) {
+    if (!mayMatch(input)) {
       return List.of();
     }
 

--- a/prism-core/src/main/java/io/github/catalin87/prism/core/detector/europe/EuVatDetector.java
+++ b/prism-core/src/main/java/io/github/catalin87/prism/core/detector/europe/EuVatDetector.java
@@ -69,8 +69,13 @@ public class EuVatDetector implements PiiDetector {
   }
 
   @Override
+  public boolean mayMatch(@NonNull String input) {
+    return PiiDetector.containsDigit(input);
+  }
+
+  @Override
   public @NonNull List<PiiCandidate> detect(@NonNull String input) {
-    if (input.isEmpty()) {
+    if (!mayMatch(input)) {
       return List.of();
     }
 

--- a/prism-core/src/main/java/io/github/catalin87/prism/core/detector/europe/IbanDetector.java
+++ b/prism-core/src/main/java/io/github/catalin87/prism/core/detector/europe/IbanDetector.java
@@ -47,8 +47,13 @@ public class IbanDetector implements PiiDetector {
   }
 
   @Override
+  public boolean mayMatch(@NonNull String input) {
+    return PiiDetector.containsDigit(input);
+  }
+
+  @Override
   public @NonNull List<PiiCandidate> detect(@NonNull String input) {
-    if (input.isEmpty()) {
+    if (!mayMatch(input)) {
       return List.of();
     }
 

--- a/prism-core/src/main/java/io/github/catalin87/prism/core/detector/europe/NinoDetector.java
+++ b/prism-core/src/main/java/io/github/catalin87/prism/core/detector/europe/NinoDetector.java
@@ -41,8 +41,13 @@ public class NinoDetector implements PiiDetector {
   }
 
   @Override
+  public boolean mayMatch(@NonNull String input) {
+    return PiiDetector.containsDigit(input);
+  }
+
+  @Override
   public @NonNull List<PiiCandidate> detect(@NonNull String input) {
-    if (input.isEmpty()) {
+    if (!mayMatch(input)) {
       return List.of();
     }
 

--- a/prism-core/src/main/java/io/github/catalin87/prism/core/detector/europe/PeselDetector.java
+++ b/prism-core/src/main/java/io/github/catalin87/prism/core/detector/europe/PeselDetector.java
@@ -40,8 +40,13 @@ public class PeselDetector implements PiiDetector {
   }
 
   @Override
+  public boolean mayMatch(@NonNull String input) {
+    return PiiDetector.containsDigit(input);
+  }
+
+  @Override
   public @NonNull List<PiiCandidate> detect(@NonNull String input) {
-    if (input.isEmpty()) {
+    if (!mayMatch(input)) {
       return List.of();
     }
 

--- a/prism-core/src/main/java/io/github/catalin87/prism/core/detector/universal/CreditCardDetector.java
+++ b/prism-core/src/main/java/io/github/catalin87/prism/core/detector/universal/CreditCardDetector.java
@@ -37,8 +37,13 @@ public class CreditCardDetector implements PiiDetector {
   }
 
   @Override
+  public boolean mayMatch(@NonNull String input) {
+    return PiiDetector.containsDigit(input);
+  }
+
+  @Override
   public @NonNull List<PiiCandidate> detect(@NonNull String input) {
-    if (input.isEmpty()) {
+    if (!mayMatch(input)) {
       return List.of();
     }
 

--- a/prism-core/src/main/java/io/github/catalin87/prism/core/detector/universal/EmailDetector.java
+++ b/prism-core/src/main/java/io/github/catalin87/prism/core/detector/universal/EmailDetector.java
@@ -40,8 +40,13 @@ public class EmailDetector implements PiiDetector {
   }
 
   @Override
+  public boolean mayMatch(@NonNull String input) {
+    return input.indexOf('@') >= 0;
+  }
+
+  @Override
   public @NonNull List<PiiCandidate> detect(@NonNull String input) {
-    if (input.isEmpty()) {
+    if (!mayMatch(input)) {
       return List.of();
     }
 

--- a/prism-core/src/main/java/io/github/catalin87/prism/core/detector/universal/IpAddressDetector.java
+++ b/prism-core/src/main/java/io/github/catalin87/prism/core/detector/universal/IpAddressDetector.java
@@ -55,8 +55,13 @@ public class IpAddressDetector implements PiiDetector {
   }
 
   @Override
+  public boolean mayMatch(@NonNull String input) {
+    return PiiDetector.containsEither(input, '.', ':');
+  }
+
+  @Override
   public @NonNull List<PiiCandidate> detect(@NonNull String input) {
-    if (input.isEmpty()) {
+    if (!mayMatch(input)) {
       return List.of();
     }
 

--- a/prism-core/src/main/java/io/github/catalin87/prism/core/detector/universal/PhoneNumberDetector.java
+++ b/prism-core/src/main/java/io/github/catalin87/prism/core/detector/universal/PhoneNumberDetector.java
@@ -38,8 +38,13 @@ public class PhoneNumberDetector implements PiiDetector {
   }
 
   @Override
+  public boolean mayMatch(@NonNull String input) {
+    return PiiDetector.containsDigit(input);
+  }
+
+  @Override
   public @NonNull List<PiiCandidate> detect(@NonNull String input) {
-    if (input.isEmpty()) {
+    if (!mayMatch(input)) {
       return List.of();
     }
 

--- a/prism-core/src/main/java/io/github/catalin87/prism/core/detector/universal/SsnDetector.java
+++ b/prism-core/src/main/java/io/github/catalin87/prism/core/detector/universal/SsnDetector.java
@@ -39,8 +39,13 @@ public class SsnDetector implements PiiDetector {
   }
 
   @Override
+  public boolean mayMatch(@NonNull String input) {
+    return PiiDetector.containsDigit(input);
+  }
+
+  @Override
   public @NonNull List<PiiCandidate> detect(@NonNull String input) {
-    if (input.isEmpty()) {
+    if (!mayMatch(input)) {
       return List.of();
     }
 

--- a/prism-langchain4j/src/main/java/io/github/catalin87/prism/langchain4j/PrismMetricsSink.java
+++ b/prism-langchain4j/src/main/java/io/github/catalin87/prism/langchain4j/PrismMetricsSink.java
@@ -20,6 +20,8 @@ import org.jspecify.annotations.NonNull;
 /** Extension hook for collecting Prism runtime metrics for LangChain4j integrations. */
 public interface PrismMetricsSink {
 
+  String LANGCHAIN4J_INTEGRATION = "langchain4j";
+
   PrismMetricsSink NOOP = new NoOpPrismMetricsSink();
 
   void onDetected(@NonNull String rulePackName, @NonNull String entityType, int count);
@@ -29,6 +31,12 @@ public interface PrismMetricsSink {
   void onTokenized(int count);
 
   void onDetokenized(int count);
+
+  void onScanDuration(@NonNull String integration, long nanos);
+
+  void onVaultTokenizeDuration(@NonNull String integration, long nanos);
+
+  void onVaultDetokenizeDuration(@NonNull String integration, long nanos);
 
   /** No-op sink used when callers do not need runtime metrics callbacks. */
   final class NoOpPrismMetricsSink implements PrismMetricsSink {
@@ -43,5 +51,14 @@ public interface PrismMetricsSink {
 
     @Override
     public void onDetokenized(int count) {}
+
+    @Override
+    public void onScanDuration(@NonNull String integration, long nanos) {}
+
+    @Override
+    public void onVaultTokenizeDuration(@NonNull String integration, long nanos) {}
+
+    @Override
+    public void onVaultDetokenizeDuration(@NonNull String integration, long nanos) {}
   }
 }

--- a/prism-langchain4j/src/main/java/io/github/catalin87/prism/langchain4j/PrismTextScanner.java
+++ b/prism-langchain4j/src/main/java/io/github/catalin87/prism/langchain4j/PrismTextScanner.java
@@ -35,6 +35,7 @@ import org.jspecify.annotations.Nullable;
 final class PrismTextScanner {
 
   private static final Pattern TOKEN_PATTERN = Pattern.compile("<PRISM_[a-zA-Z0-9_-]+>");
+  private static final String INTEGRATION = PrismMetricsSink.LANGCHAIN4J_INTEGRATION;
 
   private final List<PrismRulePack> rulePacks;
   private final PrismVault vault;
@@ -61,25 +62,33 @@ final class PrismTextScanner {
     }
 
     List<PiiCandidate> allCandidates = new ArrayList<>();
-    for (PrismRulePack pack : rulePacks) {
-      for (PiiDetector detector : pack.getDetectors()) {
-        try {
-          List<PiiCandidate> detected = detector.detect(text);
-          if (!detected.isEmpty()) {
-            metricsSink.onDetected(pack.getName(), detector.getEntityType(), detected.size());
-            allCandidates.addAll(detected);
+    long scanStartedAt = System.nanoTime();
+    try {
+      for (PrismRulePack pack : rulePacks) {
+        for (PiiDetector detector : pack.getDetectors()) {
+          if (!detector.mayMatch(text)) {
+            continue;
           }
-        } catch (Exception e) {
-          metricsSink.onDetectionError(pack.getName(), detector.getEntityType());
-          if (strictMode) {
-            throw new IllegalStateException(
-                "Strict mode blocked Prism processing after detector failure: "
-                    + detector.getEntityType(),
-                e);
+          try {
+            List<PiiCandidate> detected = detector.detect(text);
+            if (!detected.isEmpty()) {
+              metricsSink.onDetected(pack.getName(), detector.getEntityType(), detected.size());
+              allCandidates.addAll(detected);
+            }
+          } catch (Exception e) {
+            metricsSink.onDetectionError(pack.getName(), detector.getEntityType());
+            if (strictMode) {
+              throw new IllegalStateException(
+                  "Strict mode blocked Prism processing after detector failure: "
+                      + detector.getEntityType(),
+                  e);
+            }
+            observationRegistry.observationConfig().observationHandler(null);
           }
-          observationRegistry.observationConfig().observationHandler(null);
         }
       }
+    } finally {
+      metricsSink.onScanDuration(INTEGRATION, System.nanoTime() - scanStartedAt);
     }
 
     if (allCandidates.isEmpty()) {
@@ -91,10 +100,15 @@ final class PrismTextScanner {
 
     StringBuilder result = new StringBuilder(text);
     int redactedCount = 0;
-    for (PiiCandidate candidate : deduplicated) {
-      PrismToken token = vault.tokenize(candidate.text(), candidate.label());
-      result.replace(candidate.start(), candidate.end(), token.key());
-      redactedCount++;
+    long tokenizeStartedAt = System.nanoTime();
+    try {
+      for (PiiCandidate candidate : deduplicated) {
+        PrismToken token = vault.tokenize(candidate.text(), candidate.label());
+        result.replace(candidate.start(), candidate.end(), token.key());
+        redactedCount++;
+      }
+    } finally {
+      metricsSink.onVaultTokenizeDuration(INTEGRATION, System.nanoTime() - tokenizeStartedAt);
     }
 
     if (redactedCount > 0) {
@@ -113,16 +127,21 @@ final class PrismTextScanner {
     Matcher matcher = TOKEN_PATTERN.matcher(text);
     StringBuilder result = new StringBuilder(text.length());
     int detokenizedCount = 0;
-    while (matcher.find()) {
-      String tokenKey = matcher.group();
-      String original = vault.detokenize(tokenKey);
-      if (original != null) {
-        detokenizedCount++;
+    long detokenizeStartedAt = System.nanoTime();
+    try {
+      while (matcher.find()) {
+        String tokenKey = matcher.group();
+        String original = vault.detokenize(tokenKey);
+        if (original != null) {
+          detokenizedCount++;
+        }
+        matcher.appendReplacement(
+            result, Matcher.quoteReplacement(original != null ? original : tokenKey));
       }
-      matcher.appendReplacement(
-          result, Matcher.quoteReplacement(original != null ? original : tokenKey));
+      matcher.appendTail(result);
+    } finally {
+      metricsSink.onVaultDetokenizeDuration(INTEGRATION, System.nanoTime() - detokenizeStartedAt);
     }
-    matcher.appendTail(result);
     if (detokenizedCount > 0) {
       metricsSink.onDetokenized(detokenizedCount);
     }

--- a/prism-langchain4j/src/test/java/io/github/catalin87/prism/langchain4j/PrismChatModelTest.java
+++ b/prism-langchain4j/src/test/java/io/github/catalin87/prism/langchain4j/PrismChatModelTest.java
@@ -164,6 +164,37 @@ class PrismChatModelTest {
         .hasMessageContaining("Strict mode blocked Prism processing");
   }
 
+  @Test
+  void chatRecordsTimingMetrics() {
+    RecordingMetricsSink metricsSink = new RecordingMetricsSink();
+    RecordingChatModel delegate =
+        new RecordingChatModel(
+            request ->
+                ChatResponse.builder()
+                    .aiMessage(
+                        AiMessage.from(
+                            "Reply for " + vault.tokenize("user@example.com", "EMAIL").key()))
+                    .build());
+
+    PrismChatModel prismModel =
+        new PrismChatModel(
+            delegate,
+            List.of(new UniversalRulePack()),
+            vault,
+            ObservationRegistry.NOOP,
+            metricsSink,
+            false);
+
+    prismModel.chat(
+        ChatRequest.builder().messages(List.of(UserMessage.from("user@example.com"))).build());
+
+    assertThat(metricsSink.scanDurationCalls).isEqualTo(1);
+    assertThat(metricsSink.tokenizeDurationCalls).isEqualTo(1);
+    assertThat(metricsSink.detokenizeDurationCalls).isEqualTo(1);
+    assertThat(metricsSink.lastIntegration).isEqualTo(PrismMetricsSink.LANGCHAIN4J_INTEGRATION);
+    assertThat(metricsSink.lastRecordedNanos).isGreaterThanOrEqualTo(0L);
+  }
+
   private static final class RecordingChatModel implements ChatModel {
     private final ResponseFactory factory;
     private ChatRequest recordedRequest;
@@ -205,6 +236,47 @@ class PrismChatModelTest {
     @Override
     public @NonNull List<PiiCandidate> detect(@NonNull String text) {
       throw new IllegalStateException("boom");
+    }
+  }
+
+  private static final class RecordingMetricsSink implements PrismMetricsSink {
+    private int scanDurationCalls;
+    private int tokenizeDurationCalls;
+    private int detokenizeDurationCalls;
+    private String lastIntegration = "";
+    private long lastRecordedNanos;
+
+    @Override
+    public void onDetected(@NonNull String rulePackName, @NonNull String entityType, int count) {}
+
+    @Override
+    public void onDetectionError(@NonNull String rulePackName, @NonNull String entityType) {}
+
+    @Override
+    public void onTokenized(int count) {}
+
+    @Override
+    public void onDetokenized(int count) {}
+
+    @Override
+    public void onScanDuration(@NonNull String integration, long nanos) {
+      scanDurationCalls++;
+      lastIntegration = integration;
+      lastRecordedNanos = nanos;
+    }
+
+    @Override
+    public void onVaultTokenizeDuration(@NonNull String integration, long nanos) {
+      tokenizeDurationCalls++;
+      lastIntegration = integration;
+      lastRecordedNanos = nanos;
+    }
+
+    @Override
+    public void onVaultDetokenizeDuration(@NonNull String integration, long nanos) {
+      detokenizeDurationCalls++;
+      lastIntegration = integration;
+      lastRecordedNanos = nanos;
     }
   }
 }

--- a/prism-spring-ai/src/main/java/io/github/catalin87/prism/spring/ai/advisor/PrismMetricsSink.java
+++ b/prism-spring-ai/src/main/java/io/github/catalin87/prism/spring/ai/advisor/PrismMetricsSink.java
@@ -20,6 +20,8 @@ import org.jspecify.annotations.NonNull;
 /** Extension hook for collecting Prism runtime metrics without coupling core logic to a backend. */
 public interface PrismMetricsSink {
 
+  String SPRING_AI_INTEGRATION = "spring-ai";
+
   PrismMetricsSink NOOP = new NoOpPrismMetricsSink();
 
   void onDetected(@NonNull String rulePackName, @NonNull String entityType, int count);
@@ -29,6 +31,12 @@ public interface PrismMetricsSink {
   void onTokenized(int count);
 
   void onDetokenized(int count);
+
+  void onScanDuration(@NonNull String integration, long nanos);
+
+  void onVaultTokenizeDuration(@NonNull String integration, long nanos);
+
+  void onVaultDetokenizeDuration(@NonNull String integration, long nanos);
 
   /** No-op sink used when callers do not need runtime metrics callbacks. */
   final class NoOpPrismMetricsSink implements PrismMetricsSink {
@@ -43,5 +51,14 @@ public interface PrismMetricsSink {
 
     @Override
     public void onDetokenized(int count) {}
+
+    @Override
+    public void onScanDuration(@NonNull String integration, long nanos) {}
+
+    @Override
+    public void onVaultTokenizeDuration(@NonNull String integration, long nanos) {}
+
+    @Override
+    public void onVaultDetokenizeDuration(@NonNull String integration, long nanos) {}
   }
 }

--- a/prism-spring-ai/src/main/java/io/github/catalin87/prism/spring/ai/advisor/PrismTextScanner.java
+++ b/prism-spring-ai/src/main/java/io/github/catalin87/prism/spring/ai/advisor/PrismTextScanner.java
@@ -35,6 +35,7 @@ import org.jspecify.annotations.Nullable;
 class PrismTextScanner {
 
   private static final Pattern TOKEN_PATTERN = Pattern.compile("<PRISM_[a-zA-Z0-9_-]+>");
+  private static final String INTEGRATION = PrismMetricsSink.SPRING_AI_INTEGRATION;
 
   private final List<PrismRulePack> rulePacks;
   private final PrismVault vault;
@@ -77,28 +78,36 @@ class PrismTextScanner {
 
     // Collect all candidates across all detectors in all packs
     List<PiiCandidate> allCandidates = new ArrayList<>();
-    for (PrismRulePack pack : rulePacks) {
-      for (PiiDetector detector : pack.getDetectors()) {
-        try {
-          List<PiiCandidate> detected = detector.detect(text);
-          if (!detected.isEmpty()) {
-            metricsSink.onDetected(pack.getName(), detector.getEntityType(), detected.size());
-            allCandidates.addAll(detected);
+    long scanStartedAt = System.nanoTime();
+    try {
+      for (PrismRulePack pack : rulePacks) {
+        for (PiiDetector detector : pack.getDetectors()) {
+          if (!detector.mayMatch(text)) {
+            continue;
           }
-        } catch (Exception e) {
-          metricsSink.onDetectionError(pack.getName(), detector.getEntityType());
-          if (strictMode) {
-            throw new IllegalStateException(
-                "Strict mode blocked Prism processing after detector failure: "
-                    + detector.getEntityType(),
-                e);
+          try {
+            List<PiiCandidate> detected = detector.detect(text);
+            if (!detected.isEmpty()) {
+              metricsSink.onDetected(pack.getName(), detector.getEntityType(), detected.size());
+              allCandidates.addAll(detected);
+            }
+          } catch (Exception e) {
+            metricsSink.onDetectionError(pack.getName(), detector.getEntityType());
+            if (strictMode) {
+              throw new IllegalStateException(
+                  "Strict mode blocked Prism processing after detector failure: "
+                      + detector.getEntityType(),
+                  e);
+            }
+            // Fail-Open: emit metric but do not block the request
+            observationRegistry
+                .observationConfig()
+                .observationHandler(null); // triggers default handler chain
           }
-          // Fail-Open: emit metric but do not block the request
-          observationRegistry
-              .observationConfig()
-              .observationHandler(null); // triggers default handler chain
         }
       }
+    } finally {
+      metricsSink.onScanDuration(INTEGRATION, System.nanoTime() - scanStartedAt);
     }
 
     if (allCandidates.isEmpty()) {
@@ -114,10 +123,15 @@ class PrismTextScanner {
     // Replace all spans from right-to-left in the original text
     StringBuilder result = new StringBuilder(text);
     int redactedCount = 0;
-    for (PiiCandidate candidate : deduplicated) {
-      PrismToken token = vault.tokenize(candidate.text(), candidate.label());
-      result.replace(candidate.start(), candidate.end(), token.key());
-      redactedCount++;
+    long tokenizeStartedAt = System.nanoTime();
+    try {
+      for (PiiCandidate candidate : deduplicated) {
+        PrismToken token = vault.tokenize(candidate.text(), candidate.label());
+        result.replace(candidate.start(), candidate.end(), token.key());
+        redactedCount++;
+      }
+    } finally {
+      metricsSink.onVaultTokenizeDuration(INTEGRATION, System.nanoTime() - tokenizeStartedAt);
     }
 
     if (redactedCount > 0) {
@@ -145,17 +159,22 @@ class PrismTextScanner {
     Matcher matcher = TOKEN_PATTERN.matcher(text);
     StringBuilder result = new StringBuilder(text.length());
     int detokenizedCount = 0;
-    while (matcher.find()) {
-      String tokenKey = matcher.group();
-      String original = vault.detokenize(tokenKey);
-      // Fail-Open: if token not found or expired, keep the token placeholder
-      if (original != null) {
-        detokenizedCount++;
+    long detokenizeStartedAt = System.nanoTime();
+    try {
+      while (matcher.find()) {
+        String tokenKey = matcher.group();
+        String original = vault.detokenize(tokenKey);
+        // Fail-Open: if token not found or expired, keep the token placeholder
+        if (original != null) {
+          detokenizedCount++;
+        }
+        matcher.appendReplacement(
+            result, Matcher.quoteReplacement(original != null ? original : tokenKey));
       }
-      matcher.appendReplacement(
-          result, Matcher.quoteReplacement(original != null ? original : tokenKey));
+      matcher.appendTail(result);
+    } finally {
+      metricsSink.onVaultDetokenizeDuration(INTEGRATION, System.nanoTime() - detokenizeStartedAt);
     }
-    matcher.appendTail(result);
     if (detokenizedCount > 0) {
       metricsSink.onDetokenized(detokenizedCount);
     }

--- a/prism-spring-ai/src/test/java/io/github/catalin87/prism/spring/ai/advisor/PrismTextScannerTest.java
+++ b/prism-spring-ai/src/test/java/io/github/catalin87/prism/spring/ai/advisor/PrismTextScannerTest.java
@@ -149,6 +149,23 @@ class PrismTextScannerTest {
         .hasMessageContaining("Strict mode blocked Prism processing");
   }
 
+  @Test
+  void tokenizeAndDetokenizeRecordTimingMetrics() {
+    RecordingMetricsSink metricsSink = new RecordingMetricsSink();
+    PrismTextScanner timedScanner =
+        new PrismTextScanner(
+            List.of(new UniversalRulePack()), vault, ObservationRegistry.NOOP, metricsSink, false);
+
+    String tokenized = timedScanner.tokenize("Contact user@example.com.");
+    timedScanner.detokenize(tokenized);
+
+    assertThat(metricsSink.scanDurationCalls).isEqualTo(1);
+    assertThat(metricsSink.tokenizeDurationCalls).isEqualTo(1);
+    assertThat(metricsSink.detokenizeDurationCalls).isEqualTo(1);
+    assertThat(metricsSink.lastIntegration).isEqualTo(PrismMetricsSink.SPRING_AI_INTEGRATION);
+    assertThat(metricsSink.lastRecordedNanos).isGreaterThanOrEqualTo(0L);
+  }
+
   private static final class FailingRulePack implements PrismRulePack {
     @Override
     public @NonNull List<PiiDetector> getDetectors() {
@@ -170,6 +187,47 @@ class PrismTextScannerTest {
     @Override
     public @NonNull List<PiiCandidate> detect(@NonNull String text) {
       throw new IllegalStateException("boom");
+    }
+  }
+
+  private static final class RecordingMetricsSink implements PrismMetricsSink {
+    private int scanDurationCalls;
+    private int tokenizeDurationCalls;
+    private int detokenizeDurationCalls;
+    private String lastIntegration = "";
+    private long lastRecordedNanos;
+
+    @Override
+    public void onDetected(@NonNull String rulePackName, @NonNull String entityType, int count) {}
+
+    @Override
+    public void onDetectionError(@NonNull String rulePackName, @NonNull String entityType) {}
+
+    @Override
+    public void onTokenized(int count) {}
+
+    @Override
+    public void onDetokenized(int count) {}
+
+    @Override
+    public void onScanDuration(@NonNull String integration, long nanos) {
+      scanDurationCalls++;
+      lastIntegration = integration;
+      lastRecordedNanos = nanos;
+    }
+
+    @Override
+    public void onVaultTokenizeDuration(@NonNull String integration, long nanos) {
+      tokenizeDurationCalls++;
+      lastIntegration = integration;
+      lastRecordedNanos = nanos;
+    }
+
+    @Override
+    public void onVaultDetokenizeDuration(@NonNull String integration, long nanos) {
+      detokenizeDurationCalls++;
+      lastIntegration = integration;
+      lastRecordedNanos = nanos;
     }
   }
 }

--- a/prism-spring-boot-starter/src/main/java/io/github/catalin87/prism/boot/autoconfigure/MetricsController.java
+++ b/prism-spring-boot-starter/src/main/java/io/github/catalin87/prism/boot/autoconfigure/MetricsController.java
@@ -54,6 +54,7 @@ public class MetricsController {
         prismRuntimeMetrics.detokenizedCount(),
         prismRuntimeMetrics.detectionErrorCount(),
         prismRuntimeMetrics.detectionCounts(),
+        prismRuntimeMetrics.durationMetrics(),
         activeRulePacks,
         vaultType);
   }
@@ -64,6 +65,7 @@ public class MetricsController {
       long detokenizedCount,
       long detectionErrorCount,
       Map<String, Long> detectionCounts,
+      Map<String, PrismRuntimeMetrics.DurationMetric> durationMetrics,
       List<String> activeRulePacks,
       String vaultType) {}
 }

--- a/prism-spring-boot-starter/src/main/java/io/github/catalin87/prism/boot/autoconfigure/PrismRuntimeMetrics.java
+++ b/prism-spring-boot-starter/src/main/java/io/github/catalin87/prism/boot/autoconfigure/PrismRuntimeMetrics.java
@@ -29,6 +29,9 @@ public class PrismRuntimeMetrics
   private final AtomicLong detokenizedCount = new AtomicLong();
   private final AtomicLong detectionErrorCount = new AtomicLong();
   private final ConcurrentHashMap<String, AtomicLong> detectionCounts = new ConcurrentHashMap<>();
+  private final ConcurrentHashMap<String, AtomicLong> durationTotalsNanos =
+      new ConcurrentHashMap<>();
+  private final ConcurrentHashMap<String, AtomicLong> durationSamples = new ConcurrentHashMap<>();
 
   @Override
   public void onDetected(@NonNull String rulePackName, @NonNull String entityType, int count) {
@@ -52,6 +55,21 @@ public class PrismRuntimeMetrics
     detokenizedCount.addAndGet(count);
   }
 
+  @Override
+  public void onScanDuration(@NonNull String integration, long nanos) {
+    recordDuration(integration, "scan", nanos);
+  }
+
+  @Override
+  public void onVaultTokenizeDuration(@NonNull String integration, long nanos) {
+    recordDuration(integration, "vault-tokenize", nanos);
+  }
+
+  @Override
+  public void onVaultDetokenizeDuration(@NonNull String integration, long nanos) {
+    recordDuration(integration, "vault-detokenize", nanos);
+  }
+
   public long tokenizedCount() {
     return tokenizedCount.get();
   }
@@ -72,7 +90,33 @@ public class PrismRuntimeMetrics
                 Map.Entry::getKey, e -> e.getValue().get()));
   }
 
+  /**
+   * Returns an immutable snapshot of timing totals and sample counts grouped by integration path.
+   */
+  public Map<String, DurationMetric> durationMetrics() {
+    return durationTotalsNanos.entrySet().stream()
+        .collect(
+            java.util.stream.Collectors.toUnmodifiableMap(
+                Map.Entry::getKey,
+                entry -> {
+                  long totalNanos = entry.getValue().get();
+                  long samples =
+                      durationSamples.getOrDefault(entry.getKey(), new AtomicLong()).get();
+                  long averageNanos = samples == 0 ? 0 : totalNanos / samples;
+                  return new DurationMetric(samples, totalNanos, averageNanos);
+                }));
+  }
+
   private String metricKey(String rulePackName, String entityType) {
     return rulePackName + ":" + entityType;
   }
+
+  private void recordDuration(String integration, String operation, long nanos) {
+    String key = integration + ":" + operation;
+    durationTotalsNanos.computeIfAbsent(key, ignored -> new AtomicLong()).addAndGet(nanos);
+    durationSamples.computeIfAbsent(key, ignored -> new AtomicLong()).incrementAndGet();
+  }
+
+  /** Immutable timing snapshot for a single Prism runtime operation. */
+  public record DurationMetric(long samples, long totalNanos, long averageNanos) {}
 }

--- a/prism-spring-boot-starter/src/test/java/io/github/catalin87/prism/boot/autoconfigure/SpringPrismAutoConfigurationTest.java
+++ b/prism-spring-boot-starter/src/test/java/io/github/catalin87/prism/boot/autoconfigure/SpringPrismAutoConfigurationTest.java
@@ -172,11 +172,16 @@ class SpringPrismAutoConfigurationTest {
   void metricsControllerExposesRuntimeSnapshot() {
     contextRunner.run(
         context -> {
+          PrismRuntimeMetrics runtimeMetrics = context.getBean(PrismRuntimeMetrics.class);
+          runtimeMetrics.onScanDuration("spring-ai", 15L);
+          runtimeMetrics.onVaultTokenizeDuration("spring-ai", 30L);
           MetricsController controller = context.getBean(MetricsController.class);
           MetricsController.MetricsSnapshot snapshot = controller.metrics();
 
           assertThat(snapshot.activeRulePacks()).contains("UNIVERSAL");
           assertThat(snapshot.vaultType()).isNotBlank();
+          assertThat(snapshot.durationMetrics())
+              .containsKeys("spring-ai:scan", "spring-ai:vault-tokenize");
         });
   }
 

--- a/website/docs/performance.md
+++ b/website/docs/performance.md
@@ -1,0 +1,60 @@
+# Performance
+
+Spring Prism is designed to keep privacy protection practical for normal application traffic. The
+main cost centers are detector scans across prompt text and vault lookups during response
+restoration, especially when a distributed Redis vault is enabled.
+
+## What Is Optimized
+
+- Universal and European detectors now perform cheap fast-path checks before regex or checksum
+  work.
+- Spring AI and LangChain4j integrations now record scan, tokenize, and detokenize durations.
+- Runtime metrics expose timing snapshots without logging raw PII.
+
+## Runtime Timing Metrics
+
+The starter metrics endpoint at `/actuator/prism` now includes `durationMetrics` entries keyed by
+integration and operation:
+
+- `spring-ai:scan`
+- `spring-ai:vault-tokenize`
+- `spring-ai:vault-detokenize`
+- `langchain4j:scan`
+- `langchain4j:vault-tokenize`
+- `langchain4j:vault-detokenize`
+
+Each entry reports:
+
+- `samples`
+- `totalNanos`
+- `averageNanos`
+
+## Benchmarks
+
+The `prism-benchmarks` module contains JMH microbenchmarks for:
+
+- detector scan throughput
+- in-memory vault tokenization and detokenization
+- streaming token fragment restoration
+- Redis-backed vault code path overhead
+
+Build the benchmark jar:
+
+```bash
+mvn -pl prism-benchmarks -am package -DskipTests
+```
+
+Run all benchmarks:
+
+```bash
+java -jar prism-benchmarks/target/benchmarks.jar
+```
+
+Run a subset:
+
+```bash
+java -jar prism-benchmarks/target/benchmarks.jar DetectorBenchmark
+```
+
+The Redis benchmark uses an in-memory template substitute so the benchmark suite can run without a
+live Redis server during standard development flows.


### PR DESCRIPTION
## Summary
- add detector fast-path guards to avoid unnecessary scans on obvious non-matches
- record scan and vault timing metrics for Spring AI and LangChain4j integrations
- add a JMH benchmark module plus performance documentation

## Verification
- mvn -Dmaven.repo.local=/tmp/spring-prism-m2 -pl prism-core,prism-spring-ai,prism-langchain4j,prism-spring-boot-starter,prism-benchmarks -am test
- mvn -Dmaven.repo.local=/tmp/spring-prism-m2 -pl prism-benchmarks -am package -DskipTests