### PR TITLE
fix: reduce jspecify null-safety noise

### DIFF
--- a/prism-core/src/main/java/io/github/catalin87/prism/core/PiiDetector.java
+++ b/prism-core/src/main/java/io/github/catalin87/prism/core/PiiDetector.java
@@ -50,7 +50,7 @@ public interface PiiDetector {
    * @param text The source text to analyze.
    * @return A list of {@link PiiCandidate} objects indicating exact locations in the text.
    */
-  @NonNull List<PiiCandidate> detect(@NonNull String text);
+  @NonNull List<@NonNull PiiCandidate> detect(@NonNull String text);
 
   /** Returns {@code true} when the text contains at least one decimal digit. */
   static boolean containsDigit(@NonNull String text) {

--- a/prism-core/src/main/java/io/github/catalin87/prism/core/PrismRulePack.java
+++ b/prism-core/src/main/java/io/github/catalin87/prism/core/PrismRulePack.java
@@ -29,7 +29,7 @@ public interface PrismRulePack {
    *
    * @return A list of actively registered detectors provided by this rule pack.
    */
-  @NonNull List<PiiDetector> getDetectors();
+  @NonNull List<@NonNull PiiDetector> getDetectors();
 
   /**
    * Evaluates the standard geographical or contextual identifier of this matrix node.

--- a/prism-core/src/main/java/io/github/catalin87/prism/core/detector/europe/CnpDetector.java
+++ b/prism-core/src/main/java/io/github/catalin87/prism/core/detector/europe/CnpDetector.java
@@ -19,6 +19,7 @@ import io.github.catalin87.prism.core.PiiCandidate;
 import io.github.catalin87.prism.core.PiiDetector;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.jspecify.annotations.NonNull;
@@ -45,16 +46,16 @@ public class CnpDetector implements PiiDetector {
   }
 
   @Override
-  public @NonNull List<PiiCandidate> detect(@NonNull String input) {
+  public @NonNull List<@NonNull PiiCandidate> detect(@NonNull String input) {
     if (!mayMatch(input)) {
       return List.of();
     }
 
-    List<PiiCandidate> matches = new ArrayList<>();
+    List<@NonNull PiiCandidate> matches = new ArrayList<>();
     Matcher matcher = CNP_PATTERN.matcher(input);
 
     while (matcher.find()) {
-      String candidate = matcher.group();
+      String candidate = Objects.requireNonNull(matcher.group());
       if (isValidCnp(candidate)) {
         matches.add(new PiiCandidate(candidate, matcher.start(), matcher.end(), getEntityType()));
       }

--- a/prism-core/src/main/java/io/github/catalin87/prism/core/detector/europe/EuVatDetector.java
+++ b/prism-core/src/main/java/io/github/catalin87/prism/core/detector/europe/EuVatDetector.java
@@ -19,6 +19,8 @@ import io.github.catalin87.prism.core.PiiCandidate;
 import io.github.catalin87.prism.core.PiiDetector;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.jspecify.annotations.NonNull;
@@ -74,17 +76,17 @@ public class EuVatDetector implements PiiDetector {
   }
 
   @Override
-  public @NonNull List<PiiCandidate> detect(@NonNull String input) {
+  public @NonNull List<@NonNull PiiCandidate> detect(@NonNull String input) {
     if (!mayMatch(input)) {
       return List.of();
     }
 
-    List<PiiCandidate> matches = new ArrayList<>();
-    Matcher matcher = VAT_PATTERN.matcher(input.toUpperCase());
+    List<@NonNull PiiCandidate> matches = new ArrayList<>();
+    Matcher matcher = VAT_PATTERN.matcher(input.toUpperCase(Locale.ROOT));
 
     while (matcher.find()) {
       // Map back to original input positions (toUpperCase is length-preserving for ASCII)
-      String original = input.substring(matcher.start(), matcher.end());
+      String original = Objects.requireNonNull(input.substring(matcher.start(), matcher.end()));
       matches.add(new PiiCandidate(original, matcher.start(), matcher.end(), getEntityType()));
     }
 

--- a/prism-core/src/main/java/io/github/catalin87/prism/core/detector/europe/IbanDetector.java
+++ b/prism-core/src/main/java/io/github/catalin87/prism/core/detector/europe/IbanDetector.java
@@ -20,6 +20,8 @@ import io.github.catalin87.prism.core.PiiDetector;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.jspecify.annotations.NonNull;
@@ -52,22 +54,22 @@ public class IbanDetector implements PiiDetector {
   }
 
   @Override
-  public @NonNull List<PiiCandidate> detect(@NonNull String input) {
+  public @NonNull List<@NonNull PiiCandidate> detect(@NonNull String input) {
     if (!mayMatch(input)) {
       return List.of();
     }
 
-    List<PiiCandidate> matches = new ArrayList<>();
+    List<@NonNull PiiCandidate> matches = new ArrayList<>();
     scanWith(IBAN_COMPACT.matcher(input), matches);
     scanWith(IBAN_SPACED.matcher(input), matches);
 
     return matches;
   }
 
-  private void scanWith(Matcher matcher, List<PiiCandidate> matches) {
+  private void scanWith(Matcher matcher, List<@NonNull PiiCandidate> matches) {
     while (matcher.find()) {
-      String rawMatch = matcher.group();
-      String cleanIban = rawMatch.replaceAll("\\s", "").toUpperCase();
+      String rawMatch = Objects.requireNonNull(matcher.group());
+      String cleanIban = rawMatch.replaceAll("\\s", "").toUpperCase(Locale.ROOT);
       if (isValidIban(cleanIban)) {
         matches.add(new PiiCandidate(rawMatch, matcher.start(), matcher.end(), getEntityType()));
       }

--- a/prism-core/src/main/java/io/github/catalin87/prism/core/detector/europe/NinoDetector.java
+++ b/prism-core/src/main/java/io/github/catalin87/prism/core/detector/europe/NinoDetector.java
@@ -19,6 +19,7 @@ import io.github.catalin87.prism.core.PiiCandidate;
 import io.github.catalin87.prism.core.PiiDetector;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.jspecify.annotations.NonNull;
@@ -46,17 +47,17 @@ public class NinoDetector implements PiiDetector {
   }
 
   @Override
-  public @NonNull List<PiiCandidate> detect(@NonNull String input) {
+  public @NonNull List<@NonNull PiiCandidate> detect(@NonNull String input) {
     if (!mayMatch(input)) {
       return List.of();
     }
 
-    List<PiiCandidate> matches = new ArrayList<>();
+    List<@NonNull PiiCandidate> matches = new ArrayList<>();
     Matcher matcher = NINO_PATTERN.matcher(input);
 
     while (matcher.find()) {
-      matches.add(
-          new PiiCandidate(matcher.group(), matcher.start(), matcher.end(), getEntityType()));
+      String candidate = Objects.requireNonNull(matcher.group());
+      matches.add(new PiiCandidate(candidate, matcher.start(), matcher.end(), getEntityType()));
     }
 
     return matches;

--- a/prism-core/src/main/java/io/github/catalin87/prism/core/detector/europe/PeselDetector.java
+++ b/prism-core/src/main/java/io/github/catalin87/prism/core/detector/europe/PeselDetector.java
@@ -19,6 +19,7 @@ import io.github.catalin87.prism.core.PiiCandidate;
 import io.github.catalin87.prism.core.PiiDetector;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.jspecify.annotations.NonNull;
@@ -45,16 +46,16 @@ public class PeselDetector implements PiiDetector {
   }
 
   @Override
-  public @NonNull List<PiiCandidate> detect(@NonNull String input) {
+  public @NonNull List<@NonNull PiiCandidate> detect(@NonNull String input) {
     if (!mayMatch(input)) {
       return List.of();
     }
 
-    List<PiiCandidate> matches = new ArrayList<>();
+    List<@NonNull PiiCandidate> matches = new ArrayList<>();
     Matcher matcher = PESEL_PATTERN.matcher(input);
 
     while (matcher.find()) {
-      String candidate = matcher.group();
+      String candidate = Objects.requireNonNull(matcher.group());
       if (isValidPesel(candidate)) {
         matches.add(new PiiCandidate(candidate, matcher.start(), matcher.end(), getEntityType()));
       }

--- a/prism-core/src/main/java/io/github/catalin87/prism/core/detector/universal/CreditCardDetector.java
+++ b/prism-core/src/main/java/io/github/catalin87/prism/core/detector/universal/CreditCardDetector.java
@@ -19,6 +19,7 @@ import io.github.catalin87.prism.core.PiiCandidate;
 import io.github.catalin87.prism.core.PiiDetector;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.jspecify.annotations.NonNull;
@@ -42,16 +43,16 @@ public class CreditCardDetector implements PiiDetector {
   }
 
   @Override
-  public @NonNull List<PiiCandidate> detect(@NonNull String input) {
+  public @NonNull List<@NonNull PiiCandidate> detect(@NonNull String input) {
     if (!mayMatch(input)) {
       return List.of();
     }
 
-    List<PiiCandidate> matches = new ArrayList<>();
+    List<@NonNull PiiCandidate> matches = new ArrayList<>();
     Matcher matcher = CC_PATTERN.matcher(input);
 
     while (matcher.find()) {
-      String rawMatch = matcher.group();
+      String rawMatch = Objects.requireNonNull(matcher.group());
       // Sequentially strip visual boundaries (spaces and dashes) to isolate native cardinality
       String cleanedNumbers = rawMatch.replaceAll("[ -]", "");
 

--- a/prism-core/src/main/java/io/github/catalin87/prism/core/detector/universal/EmailDetector.java
+++ b/prism-core/src/main/java/io/github/catalin87/prism/core/detector/universal/EmailDetector.java
@@ -19,6 +19,7 @@ import io.github.catalin87.prism.core.PiiCandidate;
 import io.github.catalin87.prism.core.PiiDetector;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.jspecify.annotations.NonNull;
@@ -45,17 +46,17 @@ public class EmailDetector implements PiiDetector {
   }
 
   @Override
-  public @NonNull List<PiiCandidate> detect(@NonNull String input) {
+  public @NonNull List<@NonNull PiiCandidate> detect(@NonNull String input) {
     if (!mayMatch(input)) {
       return List.of();
     }
 
-    List<PiiCandidate> matches = new ArrayList<>();
+    List<@NonNull PiiCandidate> matches = new ArrayList<>();
     Matcher matcher = EMAIL_PATTERN.matcher(input);
 
     while (matcher.find()) {
-      matches.add(
-          new PiiCandidate(matcher.group(), matcher.start(), matcher.end(), getEntityType()));
+      String candidate = Objects.requireNonNull(matcher.group());
+      matches.add(new PiiCandidate(candidate, matcher.start(), matcher.end(), getEntityType()));
     }
 
     return matches;

--- a/prism-core/src/main/java/io/github/catalin87/prism/core/detector/universal/IpAddressDetector.java
+++ b/prism-core/src/main/java/io/github/catalin87/prism/core/detector/universal/IpAddressDetector.java
@@ -19,6 +19,7 @@ import io.github.catalin87.prism.core.PiiCandidate;
 import io.github.catalin87.prism.core.PiiDetector;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.jspecify.annotations.NonNull;
@@ -60,22 +61,22 @@ public class IpAddressDetector implements PiiDetector {
   }
 
   @Override
-  public @NonNull List<PiiCandidate> detect(@NonNull String input) {
+  public @NonNull List<@NonNull PiiCandidate> detect(@NonNull String input) {
     if (!mayMatch(input)) {
       return List.of();
     }
 
-    List<PiiCandidate> matches = new ArrayList<>();
+    List<@NonNull PiiCandidate> matches = new ArrayList<>();
     collectMatches(IPV4_PATTERN.matcher(input), matches);
     collectMatches(IPV6_PATTERN.matcher(input), matches);
 
     return matches;
   }
 
-  private void collectMatches(Matcher matcher, List<PiiCandidate> matches) {
+  private void collectMatches(Matcher matcher, List<@NonNull PiiCandidate> matches) {
     while (matcher.find()) {
-      matches.add(
-          new PiiCandidate(matcher.group(), matcher.start(), matcher.end(), getEntityType()));
+      String candidate = Objects.requireNonNull(matcher.group());
+      matches.add(new PiiCandidate(candidate, matcher.start(), matcher.end(), getEntityType()));
     }
   }
 }

--- a/prism-core/src/main/java/io/github/catalin87/prism/core/detector/universal/PhoneNumberDetector.java
+++ b/prism-core/src/main/java/io/github/catalin87/prism/core/detector/universal/PhoneNumberDetector.java
@@ -19,6 +19,7 @@ import io.github.catalin87.prism.core.PiiCandidate;
 import io.github.catalin87.prism.core.PiiDetector;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.jspecify.annotations.NonNull;
@@ -43,15 +44,15 @@ public class PhoneNumberDetector implements PiiDetector {
   }
 
   @Override
-  public @NonNull List<PiiCandidate> detect(@NonNull String input) {
+  public @NonNull List<@NonNull PiiCandidate> detect(@NonNull String input) {
     if (!mayMatch(input)) {
       return List.of();
     }
 
-    List<PiiCandidate> matches = new ArrayList<>();
+    List<@NonNull PiiCandidate> matches = new ArrayList<>();
     Matcher matcher = PHONE_CANDIDATE_PATTERN.matcher(input);
     while (matcher.find()) {
-      String candidate = matcher.group();
+      String candidate = Objects.requireNonNull(matcher.group());
       if (isValidPhoneCandidate(candidate)) {
         matches.add(new PiiCandidate(candidate, matcher.start(), matcher.end(), getEntityType()));
       }

--- a/prism-core/src/main/java/io/github/catalin87/prism/core/detector/universal/SsnDetector.java
+++ b/prism-core/src/main/java/io/github/catalin87/prism/core/detector/universal/SsnDetector.java
@@ -19,6 +19,7 @@ import io.github.catalin87.prism.core.PiiCandidate;
 import io.github.catalin87.prism.core.PiiDetector;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.jspecify.annotations.NonNull;
@@ -44,17 +45,17 @@ public class SsnDetector implements PiiDetector {
   }
 
   @Override
-  public @NonNull List<PiiCandidate> detect(@NonNull String input) {
+  public @NonNull List<@NonNull PiiCandidate> detect(@NonNull String input) {
     if (!mayMatch(input)) {
       return List.of();
     }
 
-    List<PiiCandidate> matches = new ArrayList<>();
+    List<@NonNull PiiCandidate> matches = new ArrayList<>();
     Matcher matcher = SSN_PATTERN.matcher(input);
 
     while (matcher.find()) {
-      matches.add(
-          new PiiCandidate(matcher.group(), matcher.start(), matcher.end(), getEntityType()));
+      String candidate = Objects.requireNonNull(matcher.group());
+      matches.add(new PiiCandidate(candidate, matcher.start(), matcher.end(), getEntityType()));
     }
 
     return matches;

--- a/prism-core/src/main/java/io/github/catalin87/prism/core/ruleset/EuropeRulePack.java
+++ b/prism-core/src/main/java/io/github/catalin87/prism/core/ruleset/EuropeRulePack.java
@@ -36,7 +36,7 @@ import org.jspecify.annotations.NonNull;
  */
 public class EuropeRulePack implements PrismRulePack {
 
-  private static final List<PiiDetector> DETECTORS =
+  private static final List<@NonNull PiiDetector> DETECTORS =
       List.of(
           new EmailDetector(),
           new CreditCardDetector(),
@@ -55,7 +55,7 @@ public class EuropeRulePack implements PrismRulePack {
   }
 
   @Override
-  public @NonNull List<PiiDetector> getDetectors() {
+  public @NonNull List<@NonNull PiiDetector> getDetectors() {
     return DETECTORS;
   }
 }

--- a/prism-core/src/main/java/io/github/catalin87/prism/core/ruleset/UniversalRulePack.java
+++ b/prism-core/src/main/java/io/github/catalin87/prism/core/ruleset/UniversalRulePack.java
@@ -31,7 +31,7 @@ import org.jspecify.annotations.NonNull;
  */
 public class UniversalRulePack implements PrismRulePack {
 
-  private static final List<PiiDetector> DETECTORS =
+  private static final List<@NonNull PiiDetector> DETECTORS =
       List.of(
           new EmailDetector(),
           new CreditCardDetector(),
@@ -45,7 +45,7 @@ public class UniversalRulePack implements PrismRulePack {
   }
 
   @Override
-  public @NonNull List<PiiDetector> getDetectors() {
+  public @NonNull List<@NonNull PiiDetector> getDetectors() {
     return DETECTORS;
   }
 }

--- a/prism-core/src/main/java/io/github/catalin87/prism/core/token/HmacSha256TokenGenerator.java
+++ b/prism-core/src/main/java/io/github/catalin87/prism/core/token/HmacSha256TokenGenerator.java
@@ -22,6 +22,8 @@ import java.nio.charset.StandardCharsets;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.util.Base64;
+import java.util.Locale;
+import java.util.Objects;
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 import org.jspecify.annotations.NonNull;
@@ -42,10 +44,17 @@ public final class HmacSha256TokenGenerator implements TokenGenerator {
       mac.init(keySpec);
 
       byte[] digest = mac.doFinal(candidate.text().getBytes(StandardCharsets.UTF_8));
-      String signature = Base64.getUrlEncoder().withoutPadding().encodeToString(digest);
+      String signature =
+          Objects.requireNonNull(Base64.getUrlEncoder().withoutPadding().encodeToString(digest));
       String suffix = toHex(digest).substring(0, 8);
 
-      String tokenKey = String.format("<PRISM_%s_%s>", candidate.label().toUpperCase(), suffix);
+      String tokenKey =
+          Objects.requireNonNull(
+              String.format(
+                  Locale.ROOT,
+                  "<PRISM_%s_%s>",
+                  candidate.label().toUpperCase(Locale.ROOT),
+                  suffix));
 
       return new PrismToken(tokenKey, candidate.text(), signature);
     } catch (NoSuchAlgorithmException | InvalidKeyException e) {
@@ -53,7 +62,7 @@ public final class HmacSha256TokenGenerator implements TokenGenerator {
     }
   }
 
-  private static String toHex(byte[] digest) {
+  private static @NonNull String toHex(byte @NonNull [] digest) {
     StringBuilder builder = new StringBuilder(digest.length * 2);
     for (byte value : digest) {
       builder.append(Character.forDigit((value >> 4) & 0xF, 16));

--- a/prism-core/src/main/java/io/github/catalin87/prism/core/vault/DefaultPrismVault.java
+++ b/prism-core/src/main/java/io/github/catalin87/prism/core/vault/DefaultPrismVault.java
@@ -21,6 +21,7 @@ import io.github.catalin87.prism.core.PrismVault;
 import io.github.catalin87.prism.core.TokenGenerator;
 import java.time.Instant;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
@@ -50,7 +51,7 @@ public class DefaultPrismVault implements PrismVault {
       @NonNull TokenGenerator tokenGenerator, byte @NonNull [] secretKey, long ttlSeconds) {
 
     this.tokenGenerator = tokenGenerator;
-    this.secretKey = secretKey;
+    this.secretKey = secretKey.clone();
     this.ttlSeconds = ttlSeconds;
   }
 
@@ -116,15 +117,16 @@ public class DefaultPrismVault implements PrismVault {
 
   private String getLabelFromToken(String tokenKey) {
     // String format boundary checks exclusively extracting the literal sequence label
-    if (tokenKey == null || !tokenKey.startsWith("<PRISM_") || !tokenKey.endsWith(">")) {
+    if (!tokenKey.startsWith("<PRISM_") || !tokenKey.endsWith(">")) {
       return "UNKNOWN";
     }
-    String inner = tokenKey.substring(1, tokenKey.length() - 1); // PRISM_LABEL_SUFFIX
+    String inner =
+        Objects.requireNonNull(tokenKey.substring(1, tokenKey.length() - 1)); // PRISM_LABEL_SUFFIX
     int firstUnderscore = inner.indexOf('_');
     int lastUnderscore = inner.lastIndexOf('_');
 
     if (firstUnderscore != -1 && lastUnderscore != -1 && firstUnderscore < lastUnderscore) {
-      return inner.substring(firstUnderscore + 1, lastUnderscore);
+      return Objects.requireNonNull(inner.substring(firstUnderscore + 1, lastUnderscore));
     }
     return "UNKNOWN";
   }

--- a/prism-core/src/main/java/io/github/catalin87/prism/core/vault/StreamingBuffer.java
+++ b/prism-core/src/main/java/io/github/catalin87/prism/core/vault/StreamingBuffer.java
@@ -15,6 +15,7 @@
  */
 package io.github.catalin87.prism.core.vault;
 
+import java.util.Objects;
 import org.jspecify.annotations.NonNull;
 
 /**
@@ -42,7 +43,7 @@ public class StreamingBuffer {
     }
 
     fragmentationBuffer.append(chunk);
-    String currentContext = fragmentationBuffer.toString();
+    String currentContext = Objects.requireNonNull(fragmentationBuffer.toString());
 
     // The boundary metric for our cryptographic tokens is strictly defined utilizing '<' and '>'.
     int lastOpenBracket = currentContext.lastIndexOf('<');
@@ -59,8 +60,8 @@ public class StreamingBuffer {
     // instantly,
     // and securely lock the dangling sequence natively inside the internal buffer bounds.
 
-    String safelyFlushable = currentContext.substring(0, lastOpenBracket);
-    String danglingTail = currentContext.substring(lastOpenBracket);
+    String safelyFlushable = Objects.requireNonNull(currentContext.substring(0, lastOpenBracket));
+    String danglingTail = Objects.requireNonNull(currentContext.substring(lastOpenBracket));
 
     fragmentationBuffer.setLength(0);
     fragmentationBuffer.append(danglingTail);
@@ -76,7 +77,7 @@ public class StreamingBuffer {
    */
   @NonNull
   public String flush() {
-    String remainder = fragmentationBuffer.toString();
+    String remainder = Objects.requireNonNull(fragmentationBuffer.toString());
     fragmentationBuffer.setLength(0);
     return remainder;
   }

--- a/prism-spring-ai/src/main/java/io/github/catalin87/prism/spring/ai/advisor/PrismChatClientAdvisor.java
+++ b/prism-spring-ai/src/main/java/io/github/catalin87/prism/spring/ai/advisor/PrismChatClientAdvisor.java
@@ -20,6 +20,8 @@ import io.github.catalin87.prism.core.PrismVault;
 import io.github.catalin87.prism.core.vault.StreamingBuffer;
 import io.micrometer.observation.ObservationRegistry;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import org.jspecify.annotations.NonNull;
 import org.springframework.ai.chat.client.advisor.api.AdvisedRequest;
@@ -122,10 +124,11 @@ public class PrismChatClientAdvisor implements CallAroundAdvisor, StreamAroundAd
   // -----------------------------------------------------------------------
 
   @Override
-  public AdvisedResponse aroundCall(AdvisedRequest advisedRequest, CallAroundAdvisorChain chain) {
+  public @NonNull AdvisedResponse aroundCall(
+      @NonNull AdvisedRequest advisedRequest, @NonNull CallAroundAdvisorChain chain) {
 
     AdvisedRequest sanitized = tokenizeRequest(advisedRequest);
-    AdvisedResponse response = chain.nextAroundCall(sanitized);
+    AdvisedResponse response = Objects.requireNonNull(chain.nextAroundCall(sanitized));
     return detokenizeResponse(response);
   }
 
@@ -134,8 +137,8 @@ public class PrismChatClientAdvisor implements CallAroundAdvisor, StreamAroundAd
   // -----------------------------------------------------------------------
 
   @Override
-  public Flux<AdvisedResponse> aroundStream(
-      AdvisedRequest advisedRequest, StreamAroundAdvisorChain chain) {
+  public @NonNull Flux<AdvisedResponse> aroundStream(
+      @NonNull AdvisedRequest advisedRequest, @NonNull StreamAroundAdvisorChain chain) {
 
     AdvisedRequest sanitized = tokenizeRequest(advisedRequest);
     StreamingBuffer buffer = new StreamingBuffer();
@@ -167,8 +170,8 @@ public class PrismChatClientAdvisor implements CallAroundAdvisor, StreamAroundAd
   // -----------------------------------------------------------------------
 
   @Override
-  public String getName() {
-    return PrismChatClientAdvisor.class.getSimpleName();
+  public @NonNull String getName() {
+    return Objects.requireNonNull(PrismChatClientAdvisor.class.getSimpleName());
   }
 
   @Override
@@ -181,29 +184,30 @@ public class PrismChatClientAdvisor implements CallAroundAdvisor, StreamAroundAd
   // -----------------------------------------------------------------------
 
   /** Scans user and system text fields in the request and replaces PII with vault tokens. */
-  private AdvisedRequest tokenizeRequest(AdvisedRequest original) {
+  private @NonNull AdvisedRequest tokenizeRequest(@NonNull AdvisedRequest original) {
     String sanitizedUserText = scanner.tokenize(original.userText());
     String sanitizedSystemText = scanner.tokenize(original.systemText());
 
-    return AdvisedRequest.from(original)
-        .userText(sanitizedUserText)
-        .systemText(sanitizedSystemText)
-        .build();
+    return Objects.requireNonNull(
+        AdvisedRequest.from(original)
+            .userText(sanitizedUserText)
+            .systemText(sanitizedSystemText)
+            .build());
   }
 
   /** Restores vault tokens found in the synchronous response back to their original values. */
-  private AdvisedResponse detokenizeResponse(AdvisedResponse original) {
+  private @NonNull AdvisedResponse detokenizeResponse(@NonNull AdvisedResponse original) {
     String raw = extractText(original);
     String restored = scanner.detokenize(raw);
     return rebuildWithText(original, restored);
   }
 
   /** Extracts the plain-text content from the first generation in the response, if available. */
-  private static String extractText(AdvisedResponse response) {
-    if (response == null || response.response() == null) {
+  private static @NonNull String extractText(@NonNull AdvisedResponse response) {
+    ChatResponse chatResponse = response.response();
+    if (chatResponse == null) {
       return "";
     }
-    ChatResponse chatResponse = response.response();
     if (chatResponse.getResults() == null || chatResponse.getResults().isEmpty()) {
       return "";
     }
@@ -219,11 +223,12 @@ public class PrismChatClientAdvisor implements CallAroundAdvisor, StreamAroundAd
    * Rebuilds an {@link AdvisedResponse} preserving all metadata but replacing the first
    * generation's text content with the supplied {@code newText}.
    */
-  private static AdvisedResponse rebuildWithText(AdvisedResponse original, String newText) {
-    if (original == null || original.response() == null) {
+  private static @NonNull AdvisedResponse rebuildWithText(
+      @NonNull AdvisedResponse original, @NonNull String newText) {
+    ChatResponse oldChat = original.response();
+    if (oldChat == null) {
       return original;
     }
-    ChatResponse oldChat = original.response();
     List<Generation> newGenerations =
         oldChat.getResults().stream()
             .map(
@@ -236,13 +241,14 @@ public class PrismChatClientAdvisor implements CallAroundAdvisor, StreamAroundAd
             .collect(Collectors.toList());
 
     ChatResponse newChat = new ChatResponse(newGenerations, oldChat.getMetadata());
-    return new AdvisedResponse(newChat, original.adviseContext());
+    Map<String, Object> adviseContext = Objects.requireNonNull(original.adviseContext());
+    return new AdvisedResponse(newChat, adviseContext);
   }
 
   /**
    * Creates a minimal synthetic {@link AdvisedResponse} carrying only a text payload (for flush).
    */
-  private static AdvisedResponse syntheticResponse(String text) {
+  private static @NonNull AdvisedResponse syntheticResponse(@NonNull String text) {
     List<Generation> gens = List.of(new Generation(new AssistantMessage(text)));
     ChatResponse chat = new ChatResponse(gens);
     return new AdvisedResponse(chat, java.util.Map.of());


### PR DESCRIPTION
## Summary
- reduce JSpecify and Eclipse null-safety noise across core detectors, rule packs, vault utilities, and the Spring AI advisor
- align inherited non-null contracts in PrismChatClientAdvisor with the Spring AI advisor interfaces
- keep the cleanup scoped to repo code only, without mixing in local Maven-cache or unrelated example changes

## Validation
- mvn -Dmaven.repo.local=/tmp/spring-prism-m2 -pl prism-core,prism-spring-ai,prism-spring-boot-starter -am test
