### PR TITLE
feat: add dashboard history and ops controls

### DIFF
--- a/prism-dashboard/src/main/resources/META-INF/resources/prism/app.js
+++ b/prism-dashboard/src/main/resources/META-INF/resources/prism/app.js
@@ -1,12 +1,20 @@
 const liveEndpoints = ["/actuator/prism", "/prism/metrics"];
 const demoEndpoint = "./demo-metrics.json";
 const searchParams = new URLSearchParams(window.location.search);
+const defaultPollingSeconds = 30;
+const maxHistoryEntries = 50;
 
 const statusPanel = document.getElementById("status-panel");
 const cardsGrid = document.getElementById("cards-grid");
 const analyticsGrid = document.getElementById("analytics-grid");
+const historyPanel = document.getElementById("history-panel");
 const refreshButton = document.getElementById("refresh-button");
 const demoButton = document.getElementById("demo-button");
+const exportButton = document.getElementById("export-button");
+const pollingToggleButton = document.getElementById("polling-toggle");
+const pollingIntervalSelect = document.getElementById("polling-interval");
+const historyLimitSelect = document.getElementById("history-limit");
+const pollingStatus = document.getElementById("polling-status");
 const modePill = document.getElementById("mode-pill");
 const auditActionFilter = document.getElementById("audit-action-filter");
 const auditSourceFilter = document.getElementById("audit-source-filter");
@@ -16,6 +24,11 @@ const auditRetentionNote = document.getElementById("audit-retention-note");
 let currentMetrics = null;
 let currentEndpoint = null;
 let demoMode = searchParams.get("demo") === "1";
+let pollingSeconds = Number(searchParams.get("poll")) || defaultPollingSeconds;
+let pollingTimer = null;
+let historySamples = [];
+
+pollingIntervalSelect.value = `${pollingSeconds}`;
 
 async function fetchJson(endpoint) {
   const response = await fetch(endpoint, {
@@ -43,9 +56,50 @@ async function fetchMetrics() {
   throw lastError ?? new Error("Unable to fetch Spring Prism metrics");
 }
 
+function updateUrlState() {
+  const nextUrl = new URL(window.location.href);
+  if (demoMode) {
+    nextUrl.searchParams.set("demo", "1");
+  } else {
+    nextUrl.searchParams.delete("demo");
+  }
+
+  if (pollingSeconds > 0 && pollingSeconds !== defaultPollingSeconds) {
+    nextUrl.searchParams.set("poll", `${pollingSeconds}`);
+  } else {
+    nextUrl.searchParams.delete("poll");
+  }
+  window.history.replaceState({}, "", nextUrl);
+}
+
 function updateModeUi() {
   modePill.textContent = demoMode ? "Demo mode" : "Live mode";
   demoButton.textContent = demoMode ? "Return to Live Data" : "Open Demo Data";
+}
+
+function updatePollingUi() {
+  const modeLabel = pollingSeconds > 0 ? `Every ${pollingSeconds}s` : "Paused";
+  document.getElementById("polling-mode").textContent = modeLabel;
+  pollingToggleButton.textContent = pollingSeconds > 0 ? "Pause Polling" : "Resume Polling";
+  pollingStatus.textContent =
+      pollingSeconds > 0
+          ? `Auto-refresh is enabled every ${pollingSeconds} seconds.`
+          : "Auto-refresh is paused. Use Refresh for a manual snapshot.";
+}
+
+function setPolling(seconds) {
+  pollingSeconds = seconds;
+  if (pollingTimer) {
+    window.clearInterval(pollingTimer);
+    pollingTimer = null;
+  }
+  if (seconds > 0) {
+    pollingTimer = window.setInterval(() => {
+      refresh();
+    }, seconds * 1000);
+  }
+  updateUrlState();
+  updatePollingUi();
 }
 
 function formatMilliseconds(durationMetric) {
@@ -53,6 +107,10 @@ function formatMilliseconds(durationMetric) {
     return "0 ms";
   }
   return `${(durationMetric.averageNanos / 1_000_000).toFixed(2)} ms`;
+}
+
+function averageMilliseconds(durationMetric) {
+  return durationMetric?.averageNanos ? durationMetric.averageNanos / 1_000_000 : 0;
 }
 
 function topDetections(detectionCounts) {
@@ -163,6 +221,38 @@ function renderTrendCards(metrics) {
   });
 }
 
+function integrationMetrics(durationMetrics, integration) {
+  return {
+    scan: durationMetrics?.[`${integration}:scan`],
+    tokenize: durationMetrics?.[`${integration}:vault-tokenize`],
+    detokenize: durationMetrics?.[`${integration}:vault-detokenize`]
+  };
+}
+
+function renderIntegrationSummary(metrics) {
+  const container = document.getElementById("integration-summary");
+  container.replaceChildren();
+
+  [
+    {name: "spring-ai", title: "Spring AI"},
+    {name: "langchain4j", title: "LangChain4j"}
+  ].forEach(integration => {
+    const values = integrationMetrics(metrics.durationMetrics, integration.name);
+    const card = document.createElement("article");
+    card.className = "integration-card";
+    card.innerHTML = `
+      <p>${integration.title}</p>
+      <strong>${formatMilliseconds(values.scan)}</strong>
+      <span>Scan avg</span>
+      <dl class="mini-metrics">
+        <div><dt>Tokenize</dt><dd>${formatMilliseconds(values.tokenize)}</dd></div>
+        <div><dt>Detokenize</dt><dd>${formatMilliseconds(values.detokenize)}</dd></div>
+      </dl>
+    `;
+    container.append(card);
+  });
+}
+
 function renderFilterOptions(select, values) {
   const currentValue = select.value;
   select.replaceChildren();
@@ -239,9 +329,113 @@ function renderAuditLog(auditEvents, retentionLimit) {
   });
 }
 
+function healthSignal(metrics) {
+  if ((metrics.detectionErrorCount ?? 0) > 0) {
+    return "Attention";
+  }
+  const scanMetric = metrics.durationMetrics?.["spring-ai:scan"]
+      ?? metrics.durationMetrics?.["langchain4j:scan"];
+  if (averageMilliseconds(scanMetric) > 25) {
+    return "Warm";
+  }
+  return "Healthy";
+}
+
+function pushHistorySample(endpoint, metrics) {
+  historySamples.push({
+    capturedAt: new Date().toISOString(),
+    endpoint,
+    totalDetections: sumDetections(metrics.detectionCounts),
+    detectionErrors: metrics.detectionErrorCount ?? 0,
+    scanMilliseconds: averageMilliseconds(
+        metrics.durationMetrics?.["spring-ai:scan"] ?? metrics.durationMetrics?.["langchain4j:scan"])
+  });
+  if (historySamples.length > maxHistoryEntries) {
+    historySamples = historySamples.slice(-maxHistoryEntries);
+  }
+}
+
+function limitedHistory() {
+  const limit = Number(historyLimitSelect.value || "25");
+  return historySamples.slice(-limit);
+}
+
+function renderSparkline(svgId, values, stroke) {
+  const svg = document.getElementById(svgId);
+  svg.replaceChildren();
+
+  if (!values.length) {
+    return;
+  }
+
+  const width = 320;
+  const height = 120;
+  const padding = 10;
+  const maxValue = Math.max(1, ...values);
+
+  const points = values.map((value, index) => {
+    const x =
+        padding
+        + ((width - padding * 2) * index) / Math.max(1, values.length - 1);
+    const y =
+        height
+        - padding
+        - ((height - padding * 2) * value) / maxValue;
+    return `${x},${y}`;
+  }).join(" ");
+
+  const polyline = document.createElementNS("http://www.w3.org/2000/svg", "polyline");
+  polyline.setAttribute("points", points);
+  polyline.setAttribute("fill", "none");
+  polyline.setAttribute("stroke", stroke);
+  polyline.setAttribute("stroke-width", "4");
+  polyline.setAttribute("stroke-linecap", "round");
+  polyline.setAttribute("stroke-linejoin", "round");
+  svg.append(polyline);
+}
+
+function renderHistory() {
+  const points = limitedHistory();
+  if (!points.length) {
+    historyPanel.classList.add("hidden");
+    return;
+  }
+
+  renderSparkline("history-detections", points.map(point => point.totalDetections), "#0f766e");
+  renderSparkline("history-errors", points.map(point => point.detectionErrors), "#b42318");
+  renderSparkline("history-scan", points.map(point => point.scanMilliseconds), "#1d4ed8");
+  historyPanel.classList.remove("hidden");
+}
+
+function exportSnapshot() {
+  if (!currentMetrics) {
+    return;
+  }
+
+  const blob = new Blob(
+      [
+        JSON.stringify(
+            {
+              endpoint: currentEndpoint,
+              exportedAt: new Date().toISOString(),
+              metrics: currentMetrics,
+              history: limitedHistory()
+            },
+            null,
+            2)
+      ],
+      {type: "application/json"});
+  const link = document.createElement("a");
+  link.href = URL.createObjectURL(blob);
+  link.download = `spring-prism-dashboard-${Date.now()}.json`;
+  link.click();
+  URL.revokeObjectURL(link.href);
+}
+
 function renderMetrics(endpoint, metrics) {
   currentMetrics = metrics;
   currentEndpoint = endpoint;
+  pushHistorySample(endpoint, metrics);
 
   const scanMetric = metrics.durationMetrics?.["spring-ai:scan"]
       ?? metrics.durationMetrics?.["langchain4j:scan"];
@@ -251,6 +445,7 @@ function renderMetrics(endpoint, metrics) {
   document.getElementById("detokenized-count").textContent = `${metrics.detokenizedCount ?? 0}`;
   document.getElementById("error-count").textContent = `${metrics.detectionErrorCount ?? 0}`;
   document.getElementById("scan-latency").textContent = formatMilliseconds(scanMetric);
+  document.getElementById("health-signal").textContent = healthSignal(metrics);
   document.getElementById("rule-packs").textContent =
       (metrics.activeRulePacks ?? []).join(", ") || "-";
   document.getElementById("timer-count").textContent =
@@ -260,8 +455,10 @@ function renderMetrics(endpoint, metrics) {
   renderTopDetections(topDetections(metrics.detectionCounts));
   renderRulePackMetrics(metrics.rulePackMetrics ?? []);
   renderTrendCards(metrics);
+  renderIntegrationSummary(metrics);
   updateAuditFilters(metrics.auditEvents ?? [], metrics.auditRetentionLimit ?? 0);
   renderAuditLog(metrics.auditEvents ?? [], metrics.auditRetentionLimit ?? 0);
+  renderHistory();
 
   statusPanel.innerHTML =
       `<strong>Connected.</strong> Reading Prism metrics from <code>${endpoint}</code>.`;
@@ -269,6 +466,7 @@ function renderMetrics(endpoint, metrics) {
   cardsGrid.classList.remove("hidden");
   analyticsGrid.classList.remove("hidden");
   updateModeUi();
+  updatePollingUi();
 }
 
 function renderError(error) {
@@ -282,7 +480,9 @@ function renderError(error) {
   statusPanel.classList.add("error-panel");
   cardsGrid.classList.add("hidden");
   analyticsGrid.classList.add("hidden");
+  historyPanel.classList.add("hidden");
   updateModeUi();
+  updatePollingUi();
 }
 
 function rerenderAuditFromCurrentState() {
@@ -290,6 +490,10 @@ function rerenderAuditFromCurrentState() {
     return;
   }
   renderAuditLog(currentMetrics.auditEvents ?? [], currentMetrics.auditRetentionLimit ?? 0);
+}
+
+function rerenderHistoryFromCurrentState() {
+  renderHistory();
 }
 
 async function refresh() {
@@ -305,18 +509,28 @@ async function refresh() {
 refreshButton.addEventListener("click", refresh);
 demoButton.addEventListener("click", async () => {
   demoMode = !demoMode;
-  const nextUrl = new URL(window.location.href);
-  if (demoMode) {
-    nextUrl.searchParams.set("demo", "1");
-  } else {
-    nextUrl.searchParams.delete("demo");
-  }
-  window.history.replaceState({}, "", nextUrl);
+  updateUrlState();
   await refresh();
 });
+exportButton.addEventListener("click", exportSnapshot);
+pollingToggleButton.addEventListener("click", () => {
+  if (pollingSeconds > 0) {
+    pollingIntervalSelect.value = "0";
+    setPolling(0);
+    return;
+  }
+  const nextSeconds = Number(pollingIntervalSelect.value || defaultPollingSeconds) || defaultPollingSeconds;
+  pollingIntervalSelect.value = `${nextSeconds}`;
+  setPolling(nextSeconds);
+});
+pollingIntervalSelect.addEventListener("change", () => {
+  setPolling(Number(pollingIntervalSelect.value || "0"));
+});
+historyLimitSelect.addEventListener("change", rerenderHistoryFromCurrentState);
 [auditActionFilter, auditSourceFilter, auditLimitFilter].forEach(element => {
   element.addEventListener("change", rerenderAuditFromCurrentState);
 });
 
 updateModeUi();
+setPolling(pollingSeconds);
 refresh();

--- a/prism-dashboard/src/main/resources/META-INF/resources/prism/index.html
+++ b/prism-dashboard/src/main/resources/META-INF/resources/prism/index.html
@@ -24,6 +24,33 @@
         <button id="refresh-button" class="refresh-button" type="button">Refresh</button>
       </section>
 
+      <section class="panel ops-panel">
+        <div class="ops-grid">
+          <label>
+            Polling
+            <select id="polling-interval">
+              <option value="0">Paused</option>
+              <option value="15">15s</option>
+              <option value="30" selected>30s</option>
+              <option value="60">60s</option>
+            </select>
+          </label>
+          <label>
+            History Window
+            <select id="history-limit">
+              <option value="10">10 points</option>
+              <option value="25" selected>25 points</option>
+              <option value="50">50 points</option>
+            </select>
+          </label>
+          <div class="ops-actions">
+            <button id="polling-toggle" class="secondary-button" type="button">Pause Polling</button>
+            <button id="export-button" class="secondary-button" type="button">Export Snapshot</button>
+          </div>
+        </div>
+        <p id="polling-status" class="ops-note">Auto-refresh is enabled every 30 seconds.</p>
+      </section>
+
       <section id="status-panel" class="panel status-panel">
         <strong>Loading dashboard metrics...</strong>
       </section>
@@ -59,8 +86,16 @@
           <h2 id="scan-latency">0 ms</h2>
           <dl class="metric-list">
             <div>
+              <dt>Health Signal</dt>
+              <dd id="health-signal">-</dd>
+            </div>
+            <div>
               <dt>Active Rule Packs</dt>
               <dd id="rule-packs">-</dd>
+            </div>
+            <div>
+              <dt>Polling</dt>
+              <dd id="polling-mode">-</dd>
             </div>
             <div>
               <dt>Tracked Timers</dt>
@@ -85,6 +120,12 @@
           <p class="label">Trend Cards</p>
           <h2>Runtime checkpoints</h2>
           <div id="trend-cards" class="trend-grid"></div>
+        </article>
+
+        <article class="panel metric-card">
+          <p class="label">Integrations</p>
+          <h2>Spring AI vs LangChain4j</h2>
+          <div id="integration-summary" class="integration-grid"></div>
         </article>
 
         <article class="panel metric-card">
@@ -115,6 +156,29 @@
           <p id="audit-retention-note" class="audit-note"></p>
           <ul id="audit-log" class="audit-list"></ul>
         </article>
+      </section>
+
+      <section id="history-panel" class="panel history-panel hidden">
+        <div class="panel-header">
+          <div>
+            <p class="label">History</p>
+            <h2>Recent runtime changes</h2>
+          </div>
+        </div>
+        <div class="history-grid">
+          <article class="history-card">
+            <p>Total detections</p>
+            <svg id="history-detections" viewBox="0 0 320 120" role="img" aria-label="Detection history chart"></svg>
+          </article>
+          <article class="history-card">
+            <p>Detection errors</p>
+            <svg id="history-errors" viewBox="0 0 320 120" role="img" aria-label="Error history chart"></svg>
+          </article>
+          <article class="history-card">
+            <p>Scan latency</p>
+            <svg id="history-scan" viewBox="0 0 320 120" role="img" aria-label="Scan latency history chart"></svg>
+          </article>
+        </div>
       </section>
 
       <section class="panel flow-panel">

--- a/prism-dashboard/src/main/resources/META-INF/resources/prism/styles.css
+++ b/prism-dashboard/src/main/resources/META-INF/resources/prism/styles.css
@@ -117,6 +117,52 @@ code {
   padding: 11px 16px;
 }
 
+.secondary-button {
+  border: 1px solid rgba(29, 24, 20, 0.12);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.8);
+  color: var(--ink);
+  cursor: pointer;
+  padding: 11px 16px;
+}
+
+.ops-panel {
+  margin-bottom: 20px;
+}
+
+.ops-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 16px;
+  align-items: end;
+}
+
+.ops-grid label {
+  display: grid;
+  gap: 6px;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.ops-grid select {
+  border: 1px solid rgba(29, 24, 20, 0.12);
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.82);
+  padding: 10px 12px;
+  color: var(--ink);
+}
+
+.ops-actions {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.ops-note {
+  margin: 14px 0 0;
+  color: var(--muted);
+}
+
 .cards-grid {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
@@ -211,6 +257,51 @@ code {
   font-size: 1.1rem;
 }
 
+.integration-grid {
+  display: grid;
+  gap: 12px;
+}
+
+.integration-card {
+  display: grid;
+  gap: 8px;
+  padding: 16px;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.72);
+  border: 1px solid rgba(29, 24, 20, 0.08);
+}
+
+.integration-card p,
+.integration-card span {
+  margin: 0;
+  color: var(--muted);
+}
+
+.integration-card strong {
+  font-size: 1.15rem;
+}
+
+.mini-metrics {
+  display: grid;
+  gap: 8px;
+  margin: 0;
+}
+
+.mini-metrics div {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.mini-metrics dt {
+  color: var(--muted);
+}
+
+.mini-metrics dd {
+  margin: 0;
+  font-weight: 700;
+}
+
 .bar-row {
   display: grid;
   gap: 8px;
@@ -300,6 +391,34 @@ code {
   font-size: 0.88rem;
 }
 
+.history-panel {
+  margin-bottom: 20px;
+}
+
+.history-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.history-card {
+  padding: 16px;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.72);
+  border: 1px solid rgba(29, 24, 20, 0.08);
+}
+
+.history-card p {
+  margin: 0 0 12px;
+  color: var(--muted);
+}
+
+.history-card svg {
+  width: 100%;
+  height: auto;
+  overflow: visible;
+}
+
 .flow-panel {
   overflow: hidden;
 }
@@ -363,8 +482,10 @@ code {
 
 @media (max-width: 940px) {
   .hero,
+  .ops-grid,
   .cards-grid,
   .analytics-grid,
+  .history-grid,
   .flow-grid {
     grid-template-columns: 1fr;
     display: grid;
@@ -381,6 +502,10 @@ code {
   .trend-grid,
   .audit-toolbar {
     grid-template-columns: 1fr;
+  }
+
+  .ops-actions {
+    flex-direction: column;
   }
 
   .flow-arrow {

--- a/website/docs/architecture.md
+++ b/website/docs/architecture.md
@@ -40,7 +40,7 @@ The embedded observability surface.
 - **Packaging**: Static assets are served from `META-INF/resources/prism/` inside the dashboard jar.
 - **Data Source**: Reads the Prism runtime snapshot from `/actuator/prism` when Actuator is present and falls back to `/prism/metrics` otherwise.
 - **Verification**: Includes a bundled `/prism/?demo=1` fixture mode for visual checks without a live runtime.
-- **Current Scope**: Dashboard shell, top-redacted metrics, vault/runtime health, rule-pack activity bars, trend cards, a masked recent-activity audit feed with filters, and a visual refraction-flow explainer.
+- **Current Scope**: Dashboard shell, top-redacted metrics, vault/runtime health, rule-pack activity bars, integration timing cards, browser-side history charts, polling/export controls, a masked recent-activity audit feed with filters, and a visual refraction-flow explainer.
 
 ## The Request Lifecycle
 

--- a/website/docs/dashboard.md
+++ b/website/docs/dashboard.md
@@ -23,7 +23,10 @@ If Actuator is not on the classpath, it falls back to:
 - Runtime pulse and tracked timer count
 - Rule-pack activity bars
 - Trend cards for leading pack, total detections, slowest timer, and audit retention
+- Integration drill-down cards for Spring AI and LangChain4j timing paths
 - Masked recent-activity audit feed with action/source/limit filters
+- Browser-side history charts for detections, errors, and scan latency
+- Polling controls plus snapshot export
 - Refraction-flow explainer
 
 ## Demo mode
@@ -42,3 +45,4 @@ Demo mode loads the packaged `demo-metrics.json` fixture and keeps all values ma
 - The dashboard only renders aggregate counters, timing summaries, and masked audit events.
 - It does not expose raw PII.
 - Audit history is intentionally bounded in memory and currently retains the most recent 12 masked events.
+- Browser history and exported snapshots only contain the same masked dashboard payload already visible in the UI.


### PR DESCRIPTION
## Summary
- add operator-focused dashboard controls for polling, history windows, and snapshot export
- add browser-side history charts plus integration timing cards for Spring AI and LangChain4j
- document the new dashboard operational surface in Docusaurus

## Validation
- mvn -Dmaven.repo.local=/tmp/spring-prism-m2 -pl prism-dashboard -am package -DskipTests
- cd website && npm run build
