### PR TITLE
feat: complete dashboard operations surface

### DIFF
--- a/prism-dashboard/src/main/resources/META-INF/resources/prism/app.js
+++ b/prism-dashboard/src/main/resources/META-INF/resources/prism/app.js
@@ -1,8 +1,8 @@
 const liveEndpoints = ["/actuator/prism", "/prism/metrics"];
 const demoEndpoint = "./demo-metrics.json";
 const searchParams = new URLSearchParams(window.location.search);
-const defaultPollingSeconds = 30;
-const maxHistoryEntries = 50;
+const fallbackPollingSeconds = 30;
+const maxRenderableHistoryEntries = 120;
 
 const statusPanel = document.getElementById("status-panel");
 const cardsGrid = document.getElementById("cards-grid");
@@ -11,9 +11,12 @@ const historyPanel = document.getElementById("history-panel");
 const refreshButton = document.getElementById("refresh-button");
 const demoButton = document.getElementById("demo-button");
 const exportButton = document.getElementById("export-button");
+const exportCsvButton = document.getElementById("export-csv-button");
+const exportSummaryButton = document.getElementById("export-summary-button");
 const pollingToggleButton = document.getElementById("polling-toggle");
 const pollingIntervalSelect = document.getElementById("polling-interval");
 const historyLimitSelect = document.getElementById("history-limit");
+const historyWindowSelect = document.getElementById("history-window");
 const pollingStatus = document.getElementById("polling-status");
 const filterStatus = document.getElementById("filter-status");
 const modePill = document.getElementById("mode-pill");
@@ -29,10 +32,9 @@ const historyRetentionNote = document.getElementById("history-retention-note");
 let currentMetrics = null;
 let currentEndpoint = null;
 let demoMode = searchParams.get("demo") === "1";
-let pollingSeconds = Number(searchParams.get("poll")) || defaultPollingSeconds;
+let pollingSeconds = Number(searchParams.get("poll") ?? "-1");
 let pollingTimer = null;
-
-pollingIntervalSelect.value = `${pollingSeconds}`;
+let serverPollingInitialized = pollingSeconds >= 0;
 
 async function fetchJson(endpoint) {
   const response = await fetch(endpoint, {
@@ -68,7 +70,7 @@ function updateUrlState() {
     nextUrl.searchParams.delete("demo");
   }
 
-  if (pollingSeconds > 0 && pollingSeconds !== defaultPollingSeconds) {
+  if (pollingSeconds > 0 && pollingSeconds !== fallbackPollingSeconds) {
     nextUrl.searchParams.set("poll", `${pollingSeconds}`);
   } else {
     nextUrl.searchParams.delete("poll");
@@ -91,8 +93,9 @@ function updatePollingUi() {
           : "Auto-refresh is paused. Use Refresh for a manual snapshot.";
 }
 
-function setPolling(seconds) {
+function setPolling(seconds, persistUrl = true) {
   pollingSeconds = seconds;
+  pollingIntervalSelect.value = `${seconds}`;
   if (pollingTimer) {
     window.clearInterval(pollingTimer);
     pollingTimer = null;
@@ -102,8 +105,21 @@ function setPolling(seconds) {
       refresh();
     }, seconds * 1000);
   }
-  updateUrlState();
+  if (persistUrl) {
+    updateUrlState();
+  }
   updatePollingUi();
+}
+
+function initializePollingFromMetrics(metrics) {
+  if (serverPollingInitialized) {
+    return;
+  }
+
+  const configuredDefault =
+      metrics.dashboardConfiguration?.defaultPollingSeconds ?? fallbackPollingSeconds;
+  serverPollingInitialized = true;
+  setPolling(configuredDefault, false);
 }
 
 function formatMilliseconds(durationMetric) {
@@ -117,14 +133,106 @@ function averageMilliseconds(durationMetric) {
   return durationMetric?.averageNanos ? durationMetric.averageNanos / 1_000_000 : 0;
 }
 
-function topDetections(detectionCounts) {
-  return Object.entries(detectionCounts ?? {})
-      .sort((left, right) => right[1] - left[1])
-      .slice(0, 4);
+function alertThresholds(metrics) {
+  return metrics.dashboardConfiguration?.alertThresholds ?? {
+    scanLatencyWarnMs: 25,
+    scanLatencyCriticalMs: 75,
+    tokenBacklogWarn: 5,
+    tokenBacklogCritical: 20,
+    detectionErrorWarn: 1,
+    detectionErrorCritical: 5
+  };
 }
 
-function sumDetections(detectionCounts) {
-  return Object.values(detectionCounts ?? {}).reduce((sum, count) => sum + count, 0);
+function selectedIntegration() {
+  return integrationFilter.value || "ALL";
+}
+
+function selectedRulePack() {
+  return rulePackFilter.value || "ALL";
+}
+
+function selectedEntity() {
+  return entityFilter.value || "ALL";
+}
+
+function selectedHistoryWindow() {
+  return historyWindowSelect.value || "ALL";
+}
+
+function renderFilterOptions(select, values) {
+  const currentValue = select.value;
+  select.replaceChildren();
+
+  const allOption = document.createElement("option");
+  allOption.value = "ALL";
+  allOption.textContent = "All";
+  select.append(allOption);
+
+  values.forEach(value => {
+    const option = document.createElement("option");
+    option.value = value;
+    option.textContent = value;
+    select.append(option);
+  });
+
+  if ([...select.options].some(option => option.value === currentValue)) {
+    select.value = currentValue;
+  }
+}
+
+function updateOperationalFilters(metrics) {
+  renderFilterOptions(
+      integrationFilter,
+      (metrics.integrationMetrics ?? []).map(integration => integration.name));
+  renderFilterOptions(
+      rulePackFilter,
+      (metrics.rulePackMetrics ?? []).map(rulePack => rulePack.name));
+  renderFilterOptions(
+      entityFilter,
+      [...new Set((metrics.entityMetrics ?? []).map(entity => entity.entityType))].sort());
+
+  filterStatus.textContent =
+      `${selectedIntegration() === "ALL" ? "All integrations" : selectedIntegration()} · `
+      + `${selectedRulePack() === "ALL" ? "all rule packs" : selectedRulePack()} · `
+      + `${selectedEntity() === "ALL" ? "all entity types" : selectedEntity()} · `
+      + `${selectedHistoryWindow() === "ALL" ? "full retained history" : selectedHistoryWindow()}`;
+}
+
+function filteredIntegrationMetrics(integrationMetrics) {
+  return integrationMetrics.filter(
+      integration => selectedIntegration() === "ALL" || integration.name === selectedIntegration());
+}
+
+function filteredRulePackMetrics(rulePackMetrics) {
+  return rulePackMetrics.filter(
+      metric => selectedRulePack() === "ALL" || metric.name === selectedRulePack());
+}
+
+function filteredEntityMetrics(entityMetrics) {
+  return entityMetrics.filter(entity =>
+    (selectedRulePack() === "ALL" || entity.rulePackName === selectedRulePack())
+    && (selectedEntity() === "ALL" || entity.entityType === selectedEntity()));
+}
+
+function detectionEntries(metrics) {
+  const filteredEntities = filteredEntityMetrics(metrics.entityMetrics ?? []);
+  if (filteredEntities.length > 0) {
+    return filteredEntities
+        .map(entity => [`${entity.rulePackName}:${entity.entityType}`, entity.detections])
+        .sort((left, right) => right[1] - left[1]);
+  }
+
+  return Object.entries(metrics.detectionCounts ?? {})
+      .sort((left, right) => right[1] - left[1]);
+}
+
+function topDetections(metrics) {
+  return detectionEntries(metrics).slice(0, 4);
+}
+
+function sumDetections(metrics) {
+  return detectionEntries(metrics).reduce((sum, [, count]) => sum + count, 0);
 }
 
 function dominantTimer(durationMetrics) {
@@ -132,7 +240,8 @@ function dominantTimer(durationMetrics) {
       .sort((left, right) => right[1].averageNanos - left[1].averageNanos)[0];
 }
 
-function renderTopDetections(detections) {
+function renderTopDetections(metrics) {
+  const detections = topDetections(metrics);
   const topList = document.getElementById("top-detections");
   const topEntity = document.getElementById("top-entity");
   topList.replaceChildren();
@@ -159,6 +268,11 @@ function renderRulePackMetrics(rulePackMetrics) {
   container.replaceChildren();
 
   const visibleMetrics = filteredRulePackMetrics(rulePackMetrics);
+  if (visibleMetrics.length === 0) {
+    container.innerHTML = "<p class=\"empty-state\">No rule-pack activity matches the current filters.</p>";
+    return;
+  }
+
   const maxDetections = Math.max(1, ...visibleMetrics.map(metric => metric.totalDetections));
   visibleMetrics.forEach(metric => {
     const row = document.createElement("div");
@@ -181,15 +295,36 @@ function renderRulePackMetrics(rulePackMetrics) {
   });
 }
 
+function historySamplesForWindow() {
+  const historySamples = currentMetrics?.historySamples ?? [];
+  const limit = Number(historyLimitSelect.value || "25");
+  const windowKey = selectedHistoryWindow();
+  let visible = historySamples;
+
+  if (windowKey !== "ALL") {
+    const now = Date.now();
+    const durations = {
+      "5m": 5 * 60 * 1000,
+      "15m": 15 * 60 * 1000,
+      "1h": 60 * 60 * 1000
+    };
+    visible = historySamples.filter(
+        sample => now - new Date(sample.capturedAt).getTime() <= durations[windowKey]);
+  }
+
+  return visible.slice(-Math.min(limit, maxRenderableHistoryEntries));
+}
+
 function renderTrendCards(metrics) {
   const trendCards = document.getElementById("trend-cards");
   trendCards.replaceChildren();
 
-  const leadingRulePack = (metrics.rulePackMetrics ?? [])[0];
-  const totalDetections = sumDetections(metrics.detectionCounts);
+  const leadingRulePack = filteredRulePackMetrics(metrics.rulePackMetrics ?? [])[0];
+  const totalDetections = sumDetections(metrics);
   const slowestTimer = dominantTimer(metrics.durationMetrics);
-  const retentionLabel =
-      `${Math.min((metrics.auditEvents ?? []).length, metrics.auditRetentionLimit ?? 0)} / ${metrics.auditRetentionLimit ?? 0}`;
+  const selectedRollup =
+      (metrics.historyRollups ?? []).find(rollup => rollup.key === selectedHistoryWindow().toLowerCase())
+      ?? (metrics.historyRollups ?? [])[0];
 
   [
     {
@@ -200,9 +335,9 @@ function renderTrendCards(metrics) {
           : "Waiting for live detections"
     },
     {
-      label: "Total Detections",
+      label: "Visible Detections",
       value: `${totalDetections}`,
-      caption: "Combined detections across all active rule packs"
+      caption: "Combined detections across the current entity and rule-pack filter"
     },
     {
       label: "Slowest Timer",
@@ -210,9 +345,11 @@ function renderTrendCards(metrics) {
       caption: slowestTimer ? formatMilliseconds(slowestTimer[1]) : "No duration samples yet"
     },
     {
-      label: "Audit Retention",
-      value: retentionLabel,
-      caption: "Masked events currently kept in the in-memory dashboard history"
+      label: "Window Rollup",
+      value: selectedRollup?.label ?? "Recent",
+      caption: selectedRollup
+          ? `${selectedRollup.sampleCount} sample(s) · ${selectedRollup.averageScanMilliseconds.toFixed(2)} ms avg scan`
+          : "No rollup data yet"
     }
   ].forEach(card => {
     const article = document.createElement("article");
@@ -226,11 +363,37 @@ function renderTrendCards(metrics) {
   });
 }
 
+function renderRollups(metrics) {
+  const container = document.getElementById("rollup-cards");
+  container.replaceChildren();
+
+  (metrics.historyRollups ?? []).forEach(rollup => {
+    const card = document.createElement("article");
+    card.className = "rollup-card";
+    card.innerHTML = `
+      <p>${rollup.label}</p>
+      <strong>${rollup.latestDetections}</strong>
+      <span>${rollup.sampleCount} sample(s) · ${rollup.averageScanMilliseconds.toFixed(2)} ms avg scan</span>
+      <dl class="mini-metrics">
+        <div><dt>Errors</dt><dd>${rollup.errorEvents}</dd></div>
+        <div><dt>Peak backlog</dt><dd>${rollup.peakTokenBacklog}</dd></div>
+      </dl>
+    `;
+    container.append(card);
+  });
+}
+
 function renderIntegrationSummary(metrics) {
   const container = document.getElementById("integration-summary");
   container.replaceChildren();
 
-  filteredIntegrationMetrics(metrics.integrationMetrics ?? []).forEach(integration => {
+  const integrations = filteredIntegrationMetrics(metrics.integrationMetrics ?? []);
+  if (integrations.length === 0) {
+    container.innerHTML = "<p class=\"empty-state\">No integration timing data matches the current filter.</p>";
+    return;
+  }
+
+  integrations.forEach(integration => {
     const title = integration.name === "spring-ai" ? "Spring AI" : "LangChain4j";
     const card = document.createElement("article");
     card.className = "integration-card";
@@ -258,23 +421,43 @@ function renderAlerts(metrics) {
   const scanMetric = metrics.durationMetrics?.["spring-ai:scan"]
       ?? metrics.durationMetrics?.["langchain4j:scan"];
   const scanMs = averageMilliseconds(scanMetric);
-  const tokenGap = Math.max(0, (metrics.tokenizedCount ?? 0) - (metrics.detokenizedCount ?? 0));
+  const tokenGap = metrics.tokenBacklog ?? Math.max(0, (metrics.tokenizedCount ?? 0) - (metrics.detokenizedCount ?? 0));
   const errorCount = metrics.detectionErrorCount ?? 0;
   const isRedis = (metrics.vaultType ?? "").toLowerCase().includes("redis");
+  const thresholds = alertThresholds(metrics);
+
+  const scanState =
+      scanMs >= thresholds.scanLatencyCriticalMs
+          ? "critical"
+          : scanMs >= thresholds.scanLatencyWarnMs ? "warn" : "healthy";
+  const backlogState =
+      tokenGap >= thresholds.tokenBacklogCritical
+          ? "critical"
+          : tokenGap >= thresholds.tokenBacklogWarn ? "warn" : "healthy";
+  const errorState =
+      errorCount >= thresholds.detectionErrorCritical
+          ? "critical"
+          : errorCount >= thresholds.detectionErrorWarn ? "warn" : "healthy";
 
   [
-    errorCount > 0
-        ? alertLevel("Detection errors", "warn", `${errorCount} detection error event(s) observed.`)
-        : alertLevel("Detection errors", "healthy", "No detection errors recorded."),
-    scanMs > 25
-        ? alertLevel("Scan latency", "warn", `${scanMs.toFixed(2)} ms average scan time.`)
-        : alertLevel("Scan latency", "healthy", `${scanMs.toFixed(2)} ms average scan time.`),
-    tokenGap > 5
-        ? alertLevel("Token backlog", "warn", `${tokenGap} more tokenizations than restorations.`)
-        : alertLevel("Token backlog", "healthy", "Tokenize/detokenize activity is balanced."),
-    isRedis
-        ? alertLevel("Vault mode", "info", "Redis-backed vault active for shared restore paths.")
-        : alertLevel("Vault mode", "info", "Local in-memory vault active for single-node operation.")
+    alertLevel(
+        "Detection errors",
+        errorState,
+        `${errorCount} detection error event(s). Warn at ${thresholds.detectionErrorWarn}, critical at ${thresholds.detectionErrorCritical}.`),
+    alertLevel(
+        "Scan latency",
+        scanState,
+        `${scanMs.toFixed(2)} ms average scan time. Warn at ${thresholds.scanLatencyWarnMs} ms, critical at ${thresholds.scanLatencyCriticalMs} ms.`),
+    alertLevel(
+        "Token backlog",
+        backlogState,
+        `${tokenGap} outstanding restore delta. Warn at ${thresholds.tokenBacklogWarn}, critical at ${thresholds.tokenBacklogCritical}.`),
+    alertLevel(
+        "Vault mode",
+        isRedis ? "info" : "healthy",
+        isRedis
+            ? "Redis-backed vault active for shared restore paths."
+            : "Local in-memory vault active for single-node operation.")
   ].forEach(alert => {
     const card = document.createElement("article");
     card.className = `alert-card alert-${alert.state}`;
@@ -304,7 +487,7 @@ function renderEntityDrilldowns(metrics) {
     return;
   }
 
-  entityMetrics.slice(0, 6).forEach(metric => {
+  entityMetrics.slice(0, 8).forEach(metric => {
     const card = document.createElement("article");
     card.className = "entity-card";
     card.innerHTML = `
@@ -342,7 +525,7 @@ function renderVaultInsights(metrics) {
     },
     {
       label: "Token balance",
-      value: `${metrics.tokenBacklog ?? Math.max(0, (metrics.tokenizedCount ?? 0) - (metrics.detokenizedCount ?? 0))}`,
+      value: `${metrics.tokenBacklog ?? 0}`,
       note: "Outstanding restore delta"
     }
   ];
@@ -359,70 +542,43 @@ function renderVaultInsights(metrics) {
   });
 }
 
-function selectedIntegration() {
-  return integrationFilter.value || "ALL";
-}
+function renderDashboardConfiguration(metrics) {
+  const container = document.getElementById("dashboard-config");
+  container.replaceChildren();
 
-function selectedRulePack() {
-  return rulePackFilter.value || "ALL";
-}
-
-function selectedEntity() {
-  return entityFilter.value || "ALL";
-}
-
-function updateOperationalFilters(metrics) {
-  renderFilterOptions(
-      integrationFilter,
-      (metrics.integrationMetrics ?? []).map(integration => integration.name));
-  renderFilterOptions(
-      rulePackFilter,
-      (metrics.rulePackMetrics ?? []).map(rulePack => rulePack.name));
-  renderFilterOptions(
-      entityFilter,
-      [...new Set((metrics.entityMetrics ?? []).map(entity => entity.entityType))].sort());
-
-  filterStatus.textContent =
-      `${selectedIntegration() === "ALL" ? "All integrations" : selectedIntegration()} · `
-      + `${selectedRulePack() === "ALL" ? "all rule packs" : selectedRulePack()} · `
-      + `${selectedEntity() === "ALL" ? "all entity types" : selectedEntity()}`;
-}
-
-function filteredIntegrationMetrics(integrationMetrics) {
-  return integrationMetrics.filter(
-      integration => selectedIntegration() === "ALL" || integration.name === selectedIntegration());
-}
-
-function filteredRulePackMetrics(rulePackMetrics) {
-  return rulePackMetrics.filter(
-      metric => selectedRulePack() === "ALL" || metric.name === selectedRulePack());
-}
-
-function filteredEntityMetrics(entityMetrics) {
-  return entityMetrics.filter(entity =>
-    (selectedRulePack() === "ALL" || entity.rulePackName === selectedRulePack())
-    && (selectedEntity() === "ALL" || entity.entityType === selectedEntity()));
-}
-
-function renderFilterOptions(select, values) {
-  const currentValue = select.value;
-  select.replaceChildren();
-
-  const allOption = document.createElement("option");
-  allOption.value = "ALL";
-  allOption.textContent = "All";
-  select.append(allOption);
-
-  values.forEach(value => {
-    const option = document.createElement("option");
-    option.value = value;
-    option.textContent = value;
-    select.append(option);
+  const config = metrics.dashboardConfiguration ?? {};
+  const thresholds = config.alertThresholds ?? {};
+  [
+    {
+      label: "Retention",
+      value: `${config.auditRetentionLimit ?? 0} / ${config.historyRetentionLimit ?? 0}`,
+      note: "Audit and history sample limits"
+    },
+    {
+      label: "Default polling",
+      value: `${config.defaultPollingSeconds ?? fallbackPollingSeconds}s`,
+      note: "Starter-provided dashboard refresh cadence"
+    },
+    {
+      label: "Scan thresholds",
+      value: `${thresholds.scanLatencyWarnMs ?? 25} / ${thresholds.scanLatencyCriticalMs ?? 75} ms`,
+      note: "Warn and critical scan latency"
+    },
+    {
+      label: "Backlog thresholds",
+      value: `${thresholds.tokenBacklogWarn ?? 5} / ${thresholds.tokenBacklogCritical ?? 20}`,
+      note: "Warn and critical token backlog"
+    }
+  ].forEach(item => {
+    const card = document.createElement("article");
+    card.className = "config-card";
+    card.innerHTML = `
+      <p>${item.label}</p>
+      <strong>${item.value}</strong>
+      <span>${item.note}</span>
+    `;
+    container.append(card);
   });
-
-  if ([...select.options].some(option => option.value === currentValue)) {
-    select.value = currentValue;
-  }
 }
 
 function updateAuditFilters(auditEvents, retentionLimit) {
@@ -481,21 +637,22 @@ function renderAuditLog(auditEvents, retentionLimit) {
 }
 
 function healthSignal(metrics) {
+  const thresholds = alertThresholds(metrics);
+  if ((metrics.detectionErrorCount ?? 0) >= thresholds.detectionErrorCritical) {
+    return "Critical";
+  }
   if ((metrics.detectionErrorCount ?? 0) > 0) {
     return "Attention";
   }
   const scanMetric = metrics.durationMetrics?.["spring-ai:scan"]
       ?? metrics.durationMetrics?.["langchain4j:scan"];
-  if (averageMilliseconds(scanMetric) > 25) {
+  if (averageMilliseconds(scanMetric) >= thresholds.scanLatencyCriticalMs) {
+    return "Critical";
+  }
+  if (averageMilliseconds(scanMetric) >= thresholds.scanLatencyWarnMs) {
     return "Warm";
   }
   return "Healthy";
-}
-
-function limitedHistory() {
-  const limit = Number(historyLimitSelect.value || "25");
-  const serverHistory = currentMetrics?.historySamples ?? [];
-  return serverHistory.slice(-Math.min(limit, maxHistoryEntries));
 }
 
 function renderSparkline(svgId, values, stroke) {
@@ -512,13 +669,8 @@ function renderSparkline(svgId, values, stroke) {
   const maxValue = Math.max(1, ...values);
 
   const points = values.map((value, index) => {
-    const x =
-        padding
-        + ((width - padding * 2) * index) / Math.max(1, values.length - 1);
-    const y =
-        height
-        - padding
-        - ((height - padding * 2) * value) / maxValue;
+    const x = padding + ((width - padding * 2) * index) / Math.max(1, values.length - 1);
+    const y = height - padding - ((height - padding * 2) * value) / maxValue;
     return `${x},${y}`;
   }).join(" ");
 
@@ -533,14 +685,14 @@ function renderSparkline(svgId, values, stroke) {
 }
 
 function renderHistory() {
-  const points = limitedHistory();
+  const points = historySamplesForWindow();
   if (!points.length) {
     historyPanel.classList.add("hidden");
     return;
   }
 
   historyRetentionNote.textContent =
-      `Server-side history retains the latest ${currentMetrics?.historyRetentionLimit ?? points.length} sample(s).`;
+      `Server-side history retains the latest ${currentMetrics?.historyRetentionLimit ?? points.length} sample(s); showing ${points.length} in the selected window.`;
   renderSparkline("history-detections", points.map(point => point.totalDetections), "#0f766e");
   renderSparkline("history-errors", points.map(point => point.detectionErrors), "#b42318");
   renderSparkline("history-scan", points.map(point => point.scanMilliseconds), "#1d4ed8");
@@ -548,34 +700,88 @@ function renderHistory() {
   historyPanel.classList.remove("hidden");
 }
 
+function triggerDownload(name, type, content) {
+  const blob = new Blob([content], {type});
+  const link = document.createElement("a");
+  link.href = URL.createObjectURL(blob);
+  link.download = name;
+  link.click();
+  URL.revokeObjectURL(link.href);
+}
+
 function exportSnapshot() {
   if (!currentMetrics) {
     return;
   }
 
-  const blob = new Blob(
-      [
-        JSON.stringify(
-            {
-              endpoint: currentEndpoint,
-              exportedAt: new Date().toISOString(),
-              metrics: currentMetrics,
-              history: limitedHistory()
-            },
-            null,
-            2)
-      ],
-      {type: "application/json"});
-  const link = document.createElement("a");
-  link.href = URL.createObjectURL(blob);
-  link.download = `spring-prism-dashboard-${Date.now()}.json`;
-  link.click();
-  URL.revokeObjectURL(link.href);
+  triggerDownload(
+      `spring-prism-dashboard-${Date.now()}.json`,
+      "application/json",
+      JSON.stringify(
+          {
+            endpoint: currentEndpoint,
+            exportedAt: new Date().toISOString(),
+            metrics: currentMetrics,
+            history: historySamplesForWindow()
+          },
+          null,
+          2));
+}
+
+function exportHistoryCsv() {
+  if (!currentMetrics) {
+    return;
+  }
+
+  const rows = ["captured_at,total_detections,detection_errors,scan_milliseconds,token_backlog,vault_type"];
+  historySamplesForWindow().forEach(sample => {
+    rows.push(
+        [
+          sample.capturedAt,
+          sample.totalDetections,
+          sample.detectionErrors,
+          sample.scanMilliseconds,
+          sample.tokenBacklog,
+          sample.vaultType
+        ].join(","));
+  });
+  triggerDownload(`spring-prism-history-${Date.now()}.csv`, "text/csv", rows.join("\n"));
+}
+
+function exportIncidentSummary() {
+  if (!currentMetrics) {
+    return;
+  }
+
+  const topEntities = topDetections(currentMetrics)
+      .map(([name, count]) => `- ${name}: ${count}`)
+      .join("\n") || "- none";
+  const rollups = (currentMetrics.historyRollups ?? [])
+      .map(rollup =>
+        `- ${rollup.label}: ${rollup.sampleCount} samples, ${rollup.latestDetections} detections, ${rollup.averageScanMilliseconds.toFixed(2)} ms avg scan`)
+      .join("\n");
+  const summary = [
+    "Spring Prism Incident Summary",
+    `Generated: ${new Date().toISOString()}`,
+    `Endpoint: ${currentEndpoint}`,
+    `Vault: ${currentMetrics.vaultType}`,
+    `Health: ${healthSignal(currentMetrics)}`,
+    `Token backlog: ${currentMetrics.tokenBacklog ?? 0}`,
+    "",
+    "Top entities",
+    topEntities,
+    "",
+    "Rollups",
+    rollups
+  ].join("\n");
+
+  triggerDownload(`spring-prism-incident-${Date.now()}.txt`, "text/plain", summary);
 }
 
 function renderMetrics(endpoint, metrics) {
   currentMetrics = metrics;
   currentEndpoint = endpoint;
+  initializePollingFromMetrics(metrics);
 
   const scanMetric = metrics.durationMetrics?.["spring-ai:scan"]
       ?? metrics.durationMetrics?.["langchain4j:scan"];
@@ -593,13 +799,15 @@ function renderMetrics(endpoint, metrics) {
   document.getElementById("endpoint-used").textContent = endpoint;
 
   updateOperationalFilters(metrics);
-  renderTopDetections(topDetections(metrics.detectionCounts));
+  renderTopDetections(metrics);
   renderRulePackMetrics(metrics.rulePackMetrics ?? []);
   renderTrendCards(metrics);
+  renderRollups(metrics);
   renderAlerts(metrics);
   renderIntegrationSummary(metrics);
   renderEntityDrilldowns(metrics);
   renderVaultInsights(metrics);
+  renderDashboardConfiguration(metrics);
   updateAuditFilters(metrics.auditEvents ?? [], metrics.auditRetentionLimit ?? 0);
   renderAuditLog(metrics.auditEvents ?? [], metrics.auditRetentionLimit ?? 0);
   renderHistory();
@@ -629,15 +837,11 @@ function renderError(error) {
   updatePollingUi();
 }
 
-function rerenderAuditFromCurrentState() {
+function rerenderCurrentMetrics() {
   if (!currentMetrics) {
     return;
   }
-  renderAuditLog(currentMetrics.auditEvents ?? [], currentMetrics.auditRetentionLimit ?? 0);
-}
-
-function rerenderHistoryFromCurrentState() {
-  renderHistory();
+  renderMetrics(currentEndpoint, currentMetrics);
 }
 
 async function refresh() {
@@ -657,27 +861,33 @@ demoButton.addEventListener("click", async () => {
   await refresh();
 });
 exportButton.addEventListener("click", exportSnapshot);
+exportCsvButton.addEventListener("click", exportHistoryCsv);
+exportSummaryButton.addEventListener("click", exportIncidentSummary);
 pollingToggleButton.addEventListener("click", () => {
   if (pollingSeconds > 0) {
-    pollingIntervalSelect.value = "0";
     setPolling(0);
     return;
   }
-  const nextSeconds = Number(pollingIntervalSelect.value || defaultPollingSeconds) || defaultPollingSeconds;
-  pollingIntervalSelect.value = `${nextSeconds}`;
+  const nextSeconds =
+      Number(pollingIntervalSelect.value || `${fallbackPollingSeconds}`) || fallbackPollingSeconds;
   setPolling(nextSeconds);
 });
 pollingIntervalSelect.addEventListener("change", () => {
   setPolling(Number(pollingIntervalSelect.value || "0"));
 });
-historyLimitSelect.addEventListener("change", rerenderHistoryFromCurrentState);
-integrationFilter.addEventListener("change", () => currentMetrics && renderMetrics(currentEndpoint, currentMetrics));
-rulePackFilter.addEventListener("change", () => currentMetrics && renderMetrics(currentEndpoint, currentMetrics));
-entityFilter.addEventListener("change", () => currentMetrics && renderMetrics(currentEndpoint, currentMetrics));
-[auditActionFilter, auditSourceFilter, auditLimitFilter].forEach(element => {
-  element.addEventListener("change", rerenderAuditFromCurrentState);
+[
+  historyLimitSelect,
+  historyWindowSelect,
+  integrationFilter,
+  rulePackFilter,
+  entityFilter,
+  auditActionFilter,
+  auditSourceFilter,
+  auditLimitFilter
+].forEach(element => {
+  element.addEventListener("change", rerenderCurrentMetrics);
 });
 
 updateModeUi();
-setPolling(pollingSeconds);
+setPolling(serverPollingInitialized ? pollingSeconds : fallbackPollingSeconds, false);
 refresh();

--- a/prism-dashboard/src/main/resources/META-INF/resources/prism/index.html
+++ b/prism-dashboard/src/main/resources/META-INF/resources/prism/index.html
@@ -11,10 +11,11 @@
       <section class="hero">
         <div>
           <p class="eyebrow">Spring Prism Dashboard</p>
-          <h1>Observe refraction health without exposing raw PII.</h1>
+          <h1>Operate Prism like a real privacy control plane.</h1>
           <p class="hero-copy">
-            This embedded dashboard reads the live Spring Prism runtime snapshot and surfaces top
-            detections, vault health, and the privacy flow around your AI requests.
+            Watch redaction traffic, vault posture, trend rollups, and alert thresholds without
+            exposing raw PII. The dashboard reads the runtime snapshot published by Spring Prism
+            and keeps every visible view aggregate or masked.
           </p>
           <div class="hero-actions">
             <span id="mode-pill" class="mode-pill">Live mode</span>
@@ -31,17 +32,27 @@
             <select id="polling-interval">
               <option value="0">Paused</option>
               <option value="15">15s</option>
-              <option value="30" selected>30s</option>
+              <option value="30">30s</option>
+              <option value="45">45s</option>
               <option value="60">60s</option>
             </select>
           </label>
           <label>
-            History Window
+            History Samples
             <select id="history-limit">
               <option value="10">10 samples</option>
               <option value="25" selected>25 samples</option>
               <option value="50">50 samples</option>
               <option value="120">Full retention</option>
+            </select>
+          </label>
+          <label>
+            Trend Window
+            <select id="history-window">
+              <option value="ALL" selected>All retained</option>
+              <option value="5m">Last 5 minutes</option>
+              <option value="15m">Last 15 minutes</option>
+              <option value="1h">Last hour</option>
             </select>
           </label>
           <label>
@@ -64,7 +75,9 @@
           </label>
           <div class="ops-actions">
             <button id="polling-toggle" class="secondary-button" type="button">Pause Polling</button>
-            <button id="export-button" class="secondary-button" type="button">Export Snapshot</button>
+            <button id="export-button" class="secondary-button" type="button">Export JSON</button>
+            <button id="export-csv-button" class="secondary-button" type="button">Export CSV</button>
+            <button id="export-summary-button" class="secondary-button" type="button">Incident Summary</button>
           </div>
         </div>
         <p id="polling-status" class="ops-note">Auto-refresh is enabled every 30 seconds.</p>
@@ -143,6 +156,12 @@
         </article>
 
         <article class="panel metric-card">
+          <p class="label">Rollups</p>
+          <h2>Server-side trend windows</h2>
+          <div id="rollup-cards" class="rollup-grid"></div>
+        </article>
+
+        <article class="panel metric-card">
           <p class="label">Alerts</p>
           <h2>Operational thresholds</h2>
           <div id="alert-cards" class="alert-grid"></div>
@@ -167,6 +186,12 @@
         </article>
 
         <article class="panel metric-card">
+          <p class="label">Admin Surface</p>
+          <h2>Retention and thresholds</h2>
+          <div id="dashboard-config" class="config-grid"></div>
+        </article>
+
+        <article class="panel metric-card">
           <p class="label">Audit Log</p>
           <h2>Masked recent activity</h2>
           <div class="audit-toolbar">
@@ -188,6 +213,7 @@
                 <option value="5">5</option>
                 <option value="8">8</option>
                 <option value="12">12</option>
+                <option value="20">20</option>
               </select>
             </label>
           </div>

--- a/prism-dashboard/src/main/resources/META-INF/resources/prism/styles.css
+++ b/prism-dashboard/src/main/resources/META-INF/resources/prism/styles.css
@@ -7,6 +7,9 @@
   --accent: #0f766e;
   --accent-strong: #134e4a;
   --danger: #b42318;
+  --danger-strong: #8e1d13;
+  --warning: #c77800;
+  --info: #1d4ed8;
   --shadow: 0 18px 40px rgba(65, 43, 24, 0.12);
   font-family: "IBM Plex Sans", "Segoe UI", sans-serif;
 }
@@ -36,7 +39,7 @@ code {
 }
 
 .dashboard-shell {
-  max-width: 1180px;
+  max-width: 1240px;
   margin: 0 auto;
   padding: 48px 20px 64px;
 }
@@ -66,13 +69,13 @@ code {
 }
 
 .hero h1 {
-  max-width: 720px;
+  max-width: 760px;
   font-size: clamp(2.3rem, 4vw, 4.3rem);
   line-height: 0.96;
 }
 
 .hero-copy {
-  max-width: 720px;
+  max-width: 760px;
   margin: 16px 0 0;
   color: var(--muted);
   font-size: 1.05rem;
@@ -132,7 +135,7 @@ code {
 
 .ops-grid {
   display: grid;
-  grid-template-columns: repeat(6, minmax(0, 1fr));
+  grid-template-columns: repeat(7, minmax(0, 1fr));
   gap: 16px;
   align-items: end;
 }
@@ -156,6 +159,7 @@ code {
   display: flex;
   gap: 12px;
   flex-wrap: wrap;
+  grid-column: span 2;
 }
 
 .ops-note {
@@ -172,7 +176,7 @@ code {
 
 .analytics-grid {
   display: grid;
-  grid-template-columns: 1.1fr 0.9fr;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 20px;
   margin-bottom: 20px;
 }
@@ -227,18 +231,30 @@ code {
   gap: 10px;
 }
 
-.bars-list {
+.bars-list,
+.alert-grid,
+.entity-grid,
+.vault-grid,
+.integration-grid,
+.config-grid {
   display: grid;
-  gap: 14px;
+  gap: 12px;
 }
 
-.trend-grid {
+.trend-grid,
+.rollup-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 12px;
 }
 
-.trend-card {
+.trend-card,
+.rollup-card,
+.alert-card,
+.entity-card,
+.vault-card,
+.integration-card,
+.config-card {
   display: grid;
   gap: 8px;
   padding: 16px;
@@ -248,51 +264,41 @@ code {
 }
 
 .trend-card p,
-.trend-card span {
-  margin: 0;
-  color: var(--muted);
-}
-
-.trend-card strong {
-  font-size: 1.1rem;
-}
-
-.alert-grid,
-.entity-grid,
-.vault-grid {
-  display: grid;
-  gap: 12px;
-}
-
-.alert-card,
-.entity-card,
-.vault-card {
-  display: grid;
-  gap: 8px;
-  padding: 16px;
-  border-radius: 18px;
-  background: rgba(255, 255, 255, 0.72);
-  border: 1px solid rgba(29, 24, 20, 0.08);
-}
-
+.trend-card span,
+.rollup-card p,
+.rollup-card span,
 .alert-card p,
 .alert-card span,
 .entity-card p,
 .entity-card span,
 .vault-card p,
-.vault-card span {
+.vault-card span,
+.integration-card p,
+.integration-card span,
+.config-card p,
+.config-card span {
   margin: 0;
   color: var(--muted);
 }
 
+.trend-card strong,
+.rollup-card strong,
 .alert-card strong,
 .entity-card strong,
-.vault-card strong {
+.vault-card strong,
+.integration-card strong,
+.config-card strong {
   font-size: 1.05rem;
 }
 
+.alert-critical {
+  border-color: rgba(142, 29, 19, 0.32);
+  background: rgba(180, 35, 24, 0.08);
+}
+
 .alert-warn {
-  border-color: rgba(180, 35, 24, 0.22);
+  border-color: rgba(199, 120, 0, 0.28);
+  background: rgba(199, 120, 0, 0.08);
 }
 
 .alert-healthy {
@@ -301,30 +307,6 @@ code {
 
 .alert-info {
   border-color: rgba(29, 78, 216, 0.18);
-}
-
-.integration-grid {
-  display: grid;
-  gap: 12px;
-}
-
-.integration-card {
-  display: grid;
-  gap: 8px;
-  padding: 16px;
-  border-radius: 18px;
-  background: rgba(255, 255, 255, 0.72);
-  border: 1px solid rgba(29, 24, 20, 0.08);
-}
-
-.integration-card p,
-.integration-card span {
-  margin: 0;
-  color: var(--muted);
-}
-
-.integration-card strong {
-  font-size: 1.15rem;
 }
 
 .mini-metrics {
@@ -415,7 +397,8 @@ code {
 }
 
 .audit-item,
-.audit-empty {
+.audit-empty,
+.empty-state {
   display: flex;
   justify-content: space-between;
   gap: 14px;
@@ -426,7 +409,8 @@ code {
 }
 
 .audit-item p,
-.audit-empty {
+.audit-empty,
+.empty-state {
   margin: 6px 0 0;
   color: var(--muted);
 }
@@ -441,17 +425,18 @@ code {
   margin-bottom: 20px;
 }
 
+.panel-header {
+  margin-bottom: 18px;
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: flex-start;
+}
+
 .history-grid {
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
   gap: 16px;
-}
-
-.history-note {
-  margin: 0;
-  color: var(--muted);
-  max-width: 320px;
-  text-align: right;
 }
 
 .history-card {
@@ -472,12 +457,15 @@ code {
   overflow: visible;
 }
 
-.flow-panel {
-  overflow: hidden;
+.history-note {
+  margin: 0;
+  color: var(--muted);
+  max-width: 340px;
+  text-align: right;
 }
 
-.panel-header {
-  margin-bottom: 18px;
+.flow-panel {
+  overflow: hidden;
 }
 
 .flow-grid {
@@ -533,21 +521,24 @@ code {
   display: none;
 }
 
+@media (max-width: 1080px) {
+  .ops-grid,
+  .analytics-grid,
+  .cards-grid,
+  .history-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .ops-actions {
+    grid-column: span 2;
+  }
+}
+
 @media (max-width: 940px) {
   .hero,
-  .cards-grid,
-  .analytics-grid,
   .flow-grid {
     grid-template-columns: 1fr;
     display: grid;
-  }
-
-  .ops-grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-
-  .history-grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
   .hero {
@@ -559,12 +550,9 @@ code {
   }
 
   .trend-grid,
+  .rollup-grid,
   .audit-toolbar {
     grid-template-columns: 1fr;
-  }
-
-  .ops-actions {
-    flex-direction: column;
   }
 
   .flow-arrow {
@@ -573,8 +561,27 @@ code {
 }
 
 @media (max-width: 640px) {
+  .dashboard-shell {
+    padding: 28px 16px 48px;
+  }
+
   .ops-grid,
+  .cards-grid,
+  .analytics-grid,
   .history-grid {
     grid-template-columns: 1fr;
+  }
+
+  .ops-actions {
+    grid-column: span 1;
+    flex-direction: column;
+  }
+
+  .panel-header {
+    flex-direction: column;
+  }
+
+  .history-note {
+    text-align: left;
   }
 }

--- a/prism-examples/langchain4j-example/src/main/resources/application.yml
+++ b/prism-examples/langchain4j-example/src/main/resources/application.yml
@@ -2,6 +2,13 @@ spring:
   prism:
     app-secret: example-langchain4j-secret
     locales: UNIVERSAL
+    dashboard:
+      default-polling-seconds: 15
+      audit-retention: 16
+      history-retention: 180
+      alert-thresholds:
+        scan-latency-warn-ms: 20
+        scan-latency-critical-ms: 60
 management:
   endpoints:
     web:

--- a/prism-examples/spring-ai-example/src/main/resources/application.yml
+++ b/prism-examples/spring-ai-example/src/main/resources/application.yml
@@ -2,6 +2,13 @@ spring:
   prism:
     app-secret: example-spring-ai-secret
     locales: UNIVERSAL
+    dashboard:
+      default-polling-seconds: 15
+      audit-retention: 16
+      history-retention: 180
+      alert-thresholds:
+        scan-latency-warn-ms: 20
+        scan-latency-critical-ms: 60
 management:
   endpoints:
     web:

--- a/prism-spring-boot-starter/src/main/java/io/github/catalin87/prism/boot/autoconfigure/DashboardAlertThresholds.java
+++ b/prism-spring-boot-starter/src/main/java/io/github/catalin87/prism/boot/autoconfigure/DashboardAlertThresholds.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2026 Catalin Dordea and Spring Prism Contributors
+ *
+ * Licensed under the EUPL, Version 1.2 or later (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and
+ * limitations under the Licence.
+ */
+package io.github.catalin87.prism.boot.autoconfigure;
+
+/** Immutable alert thresholds published to the dashboard so UI logic stays config-driven. */
+public record DashboardAlertThresholds(
+    double scanLatencyWarnMs,
+    double scanLatencyCriticalMs,
+    long tokenBacklogWarn,
+    long tokenBacklogCritical,
+    long detectionErrorWarn,
+    long detectionErrorCritical) {}

--- a/prism-spring-boot-starter/src/main/java/io/github/catalin87/prism/boot/autoconfigure/DashboardConfiguration.java
+++ b/prism-spring-boot-starter/src/main/java/io/github/catalin87/prism/boot/autoconfigure/DashboardConfiguration.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026 Catalin Dordea and Spring Prism Contributors
+ *
+ * Licensed under the EUPL, Version 1.2 or later (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and
+ * limitations under the Licence.
+ */
+package io.github.catalin87.prism.boot.autoconfigure;
+
+/** Immutable dashboard configuration snapshot returned to the embedded UI. */
+public record DashboardConfiguration(
+    int auditRetentionLimit,
+    int historyRetentionLimit,
+    int defaultPollingSeconds,
+    DashboardAlertThresholds alertThresholds) {}

--- a/prism-spring-boot-starter/src/main/java/io/github/catalin87/prism/boot/autoconfigure/HistoryRollup.java
+++ b/prism-spring-boot-starter/src/main/java/io/github/catalin87/prism/boot/autoconfigure/HistoryRollup.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2026 Catalin Dordea and Spring Prism Contributors
+ *
+ * Licensed under the EUPL, Version 1.2 or later (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and
+ * limitations under the Licence.
+ */
+package io.github.catalin87.prism.boot.autoconfigure;
+
+/** Immutable server-side rollup summarizing a recent dashboard history window. */
+public record HistoryRollup(
+    String key,
+    String label,
+    int sampleCount,
+    long latestDetections,
+    long errorEvents,
+    double averageScanMilliseconds,
+    long peakTokenBacklog) {}

--- a/prism-spring-boot-starter/src/main/java/io/github/catalin87/prism/boot/autoconfigure/MetricsController.java
+++ b/prism-spring-boot-starter/src/main/java/io/github/catalin87/prism/boot/autoconfigure/MetricsController.java
@@ -31,21 +31,24 @@ public class MetricsController {
   private final PrismRuntimeMetrics prismRuntimeMetrics;
   private final List<PrismRulePack> springPrismRulePacks;
   private final PrismVault prismVault;
+  private final SpringPrismProperties springPrismProperties;
 
   /** Creates the metrics controller with the active rule packs, vault, and runtime counters. */
   public MetricsController(
       PrismRuntimeMetrics prismRuntimeMetrics,
       @Qualifier("springPrismRulePacks") List<PrismRulePack> springPrismRulePacks,
-      PrismVault prismVault) {
+      PrismVault prismVault,
+      SpringPrismProperties springPrismProperties) {
     this.prismRuntimeMetrics = prismRuntimeMetrics;
     this.springPrismRulePacks = springPrismRulePacks;
     this.prismVault = prismVault;
+    this.springPrismProperties = springPrismProperties;
   }
 
   /** Returns the current Spring Prism runtime snapshot for non-Actuator consumers. */
   @GetMapping
   public PrismMetricsSnapshot metrics() {
     return PrismMetricsSnapshotFactory.create(
-        prismRuntimeMetrics, springPrismRulePacks, prismVault);
+        prismRuntimeMetrics, springPrismRulePacks, prismVault, springPrismProperties);
   }
 }

--- a/prism-spring-boot-starter/src/main/java/io/github/catalin87/prism/boot/autoconfigure/PrismActuatorEndpoint.java
+++ b/prism-spring-boot-starter/src/main/java/io/github/catalin87/prism/boot/autoconfigure/PrismActuatorEndpoint.java
@@ -29,21 +29,24 @@ public class PrismActuatorEndpoint {
   private final PrismRuntimeMetrics prismRuntimeMetrics;
   private final List<PrismRulePack> springPrismRulePacks;
   private final PrismVault prismVault;
+  private final SpringPrismProperties springPrismProperties;
 
   /** Creates the actuator endpoint with the active rule packs, vault, and runtime counters. */
   public PrismActuatorEndpoint(
       PrismRuntimeMetrics prismRuntimeMetrics,
       @Qualifier("springPrismRulePacks") List<PrismRulePack> springPrismRulePacks,
-      PrismVault prismVault) {
+      PrismVault prismVault,
+      SpringPrismProperties springPrismProperties) {
     this.prismRuntimeMetrics = prismRuntimeMetrics;
     this.springPrismRulePacks = springPrismRulePacks;
     this.prismVault = prismVault;
+    this.springPrismProperties = springPrismProperties;
   }
 
   /** Returns the current Spring Prism runtime snapshot for actuator consumers. */
   @ReadOperation
   public PrismMetricsSnapshot metrics() {
     return PrismMetricsSnapshotFactory.create(
-        prismRuntimeMetrics, springPrismRulePacks, prismVault);
+        prismRuntimeMetrics, springPrismRulePacks, prismVault, springPrismProperties);
   }
 }

--- a/prism-spring-boot-starter/src/main/java/io/github/catalin87/prism/boot/autoconfigure/PrismMetricsSnapshot.java
+++ b/prism-spring-boot-starter/src/main/java/io/github/catalin87/prism/boot/autoconfigure/PrismMetricsSnapshot.java
@@ -29,10 +29,12 @@ public record PrismMetricsSnapshot(
     List<EntityMetric> entityMetrics,
     List<IntegrationMetric> integrationMetrics,
     List<HistorySample> historySamples,
+    List<HistoryRollup> historyRollups,
     int historyRetentionLimit,
     List<PrismRuntimeMetrics.AuditEvent> auditEvents,
     int auditRetentionLimit,
     List<String> activeRulePacks,
     String vaultType,
     boolean distributedVault,
-    long tokenBacklog) {}
+    long tokenBacklog,
+    DashboardConfiguration dashboardConfiguration) {}

--- a/prism-spring-boot-starter/src/main/java/io/github/catalin87/prism/boot/autoconfigure/PrismMetricsSnapshotFactory.java
+++ b/prism-spring-boot-starter/src/main/java/io/github/catalin87/prism/boot/autoconfigure/PrismMetricsSnapshotFactory.java
@@ -17,6 +17,8 @@ package io.github.catalin87.prism.boot.autoconfigure;
 
 import io.github.catalin87.prism.core.PrismRulePack;
 import io.github.catalin87.prism.core.PrismVault;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -30,7 +32,8 @@ final class PrismMetricsSnapshotFactory {
   static PrismMetricsSnapshot create(
       PrismRuntimeMetrics prismRuntimeMetrics,
       List<PrismRulePack> springPrismRulePacks,
-      PrismVault prismVault) {
+      PrismVault prismVault,
+      SpringPrismProperties properties) {
     Map<String, Long> detectionCounts = prismRuntimeMetrics.detectionCounts();
     List<String> activeRulePacks =
         springPrismRulePacks.stream().map(PrismRulePack::getName).toList();
@@ -79,8 +82,11 @@ final class PrismMetricsSnapshotFactory {
             .toList();
     String vaultType = prismVault.getClass().getSimpleName();
     prismRuntimeMetrics.captureHistorySample(vaultType);
+    List<HistorySample> historySamples = prismRuntimeMetrics.recentHistorySamples();
     long tokenBacklog =
         Math.max(0, prismRuntimeMetrics.tokenizedCount() - prismRuntimeMetrics.detokenizedCount());
+    DashboardConfiguration dashboardConfiguration =
+        dashboardConfiguration(prismRuntimeMetrics, properties);
     return new PrismMetricsSnapshot(
         prismRuntimeMetrics.tokenizedCount(),
         prismRuntimeMetrics.detokenizedCount(),
@@ -90,13 +96,70 @@ final class PrismMetricsSnapshotFactory {
         rulePackMetrics,
         entityMetrics,
         integrationMetrics,
-        prismRuntimeMetrics.recentHistorySamples(),
+        historySamples,
+        historyRollups(historySamples),
         prismRuntimeMetrics.historyRetentionLimit(),
         prismRuntimeMetrics.recentAuditEvents(),
         prismRuntimeMetrics.auditRetentionLimit(),
         activeRulePacks,
         vaultType,
         vaultType.toLowerCase().contains("redis"),
-        tokenBacklog);
+        tokenBacklog,
+        dashboardConfiguration);
+  }
+
+  private static DashboardConfiguration dashboardConfiguration(
+      PrismRuntimeMetrics prismRuntimeMetrics, SpringPrismProperties properties) {
+    SpringPrismProperties.AlertThresholds alertThresholds =
+        properties.getDashboard().getAlertThresholds();
+    return new DashboardConfiguration(
+        prismRuntimeMetrics.auditRetentionLimit(),
+        prismRuntimeMetrics.historyRetentionLimit(),
+        properties.getDashboard().getDefaultPollingSeconds(),
+        new DashboardAlertThresholds(
+            alertThresholds.getScanLatencyWarnMs(),
+            alertThresholds.getScanLatencyCriticalMs(),
+            alertThresholds.getTokenBacklogWarn(),
+            alertThresholds.getTokenBacklogCritical(),
+            alertThresholds.getDetectionErrorWarn(),
+            alertThresholds.getDetectionErrorCritical()));
+  }
+
+  private static List<HistoryRollup> historyRollups(List<HistorySample> historySamples) {
+    Instant now = Instant.now();
+    return List.of(
+        rollup("recent", "Recent", historySamples),
+        rollup("5m", "5 minutes", within(historySamples, now, Duration.ofMinutes(5))),
+        rollup("15m", "15 minutes", within(historySamples, now, Duration.ofMinutes(15))),
+        rollup("1h", "1 hour", within(historySamples, now, Duration.ofHours(1))));
+  }
+
+  private static List<HistorySample> within(
+      List<HistorySample> historySamples, Instant now, Duration duration) {
+    Instant cutoff = now.minus(duration);
+    return historySamples.stream()
+        .filter(sample -> Instant.parse(sample.capturedAt()).isAfter(cutoff))
+        .toList();
+  }
+
+  private static HistoryRollup rollup(String key, String label, List<HistorySample> samples) {
+    if (samples.isEmpty()) {
+      return new HistoryRollup(key, label, 0, 0, 0, 0d, 0);
+    }
+
+    long latestDetections = samples.getLast().totalDetections();
+    long errorEvents = samples.stream().mapToLong(HistorySample::detectionErrors).max().orElse(0);
+    double averageScanMilliseconds =
+        samples.stream().mapToDouble(HistorySample::scanMilliseconds).average().orElse(0d);
+    long peakTokenBacklog = samples.stream().mapToLong(HistorySample::tokenBacklog).max().orElse(0);
+
+    return new HistoryRollup(
+        key,
+        label,
+        samples.size(),
+        latestDetections,
+        errorEvents,
+        averageScanMilliseconds,
+        peakTokenBacklog);
   }
 }

--- a/prism-spring-boot-starter/src/main/java/io/github/catalin87/prism/boot/autoconfigure/PrismRuntimeMetrics.java
+++ b/prism-spring-boot-starter/src/main/java/io/github/catalin87/prism/boot/autoconfigure/PrismRuntimeMetrics.java
@@ -28,9 +28,6 @@ public class PrismRuntimeMetrics
     implements io.github.catalin87.prism.spring.ai.advisor.PrismMetricsSink,
         io.github.catalin87.prism.langchain4j.PrismMetricsSink {
 
-  private static final int MAX_AUDIT_EVENTS = 12;
-  private static final int MAX_HISTORY_SAMPLES = 120;
-
   private final AtomicLong tokenizedCount = new AtomicLong();
   private final AtomicLong detokenizedCount = new AtomicLong();
   private final AtomicLong detectionErrorCount = new AtomicLong();
@@ -40,6 +37,17 @@ public class PrismRuntimeMetrics
   private final ConcurrentHashMap<String, AtomicLong> durationSamples = new ConcurrentHashMap<>();
   private final Deque<AuditEvent> auditEvents = new ArrayDeque<>();
   private final Deque<HistorySample> historySamples = new ArrayDeque<>();
+  private final int auditRetentionLimit;
+  private final int historyRetentionLimit;
+
+  public PrismRuntimeMetrics() {
+    this(12, 120);
+  }
+
+  public PrismRuntimeMetrics(int auditRetentionLimit, int historyRetentionLimit) {
+    this.auditRetentionLimit = Math.max(1, auditRetentionLimit);
+    this.historyRetentionLimit = Math.max(10, historyRetentionLimit);
+  }
 
   @Override
   public void onDetected(@NonNull String rulePackName, @NonNull String entityType, int count) {
@@ -126,7 +134,7 @@ public class PrismRuntimeMetrics
 
   /** Returns the maximum number of masked audit events retained in memory. */
   public int auditRetentionLimit() {
-    return MAX_AUDIT_EVENTS;
+    return auditRetentionLimit;
   }
 
   /** Returns a recent bounded server-side history of aggregate dashboard snapshots. */
@@ -136,7 +144,7 @@ public class PrismRuntimeMetrics
 
   /** Returns the maximum number of server-side history samples retained in memory. */
   public int historyRetentionLimit() {
-    return MAX_HISTORY_SAMPLES;
+    return historyRetentionLimit;
   }
 
   /** Captures a single aggregate sample so dashboard trends survive browser refreshes. */
@@ -155,7 +163,7 @@ public class PrismRuntimeMetrics
             detokenized,
             Math.max(0, tokenized - detokenized),
             vaultType));
-    while (historySamples.size() > MAX_HISTORY_SAMPLES) {
+    while (historySamples.size() > historyRetentionLimit) {
       historySamples.removeFirst();
     }
   }
@@ -183,7 +191,7 @@ public class PrismRuntimeMetrics
 
   private synchronized void recordEvent(String action, String subject, long count, String source) {
     auditEvents.addFirst(new AuditEvent(Instant.now().toString(), action, subject, count, source));
-    while (auditEvents.size() > MAX_AUDIT_EVENTS) {
+    while (auditEvents.size() > auditRetentionLimit) {
       auditEvents.removeLast();
     }
   }

--- a/prism-spring-boot-starter/src/main/java/io/github/catalin87/prism/boot/autoconfigure/SpringPrismAutoConfiguration.java
+++ b/prism-spring-boot-starter/src/main/java/io/github/catalin87/prism/boot/autoconfigure/SpringPrismAutoConfiguration.java
@@ -85,8 +85,9 @@ public class SpringPrismAutoConfiguration {
 
   @Bean
   @ConditionalOnMissingBean
-  PrismRuntimeMetrics prismRuntimeMetrics() {
-    return new PrismRuntimeMetrics();
+  PrismRuntimeMetrics prismRuntimeMetrics(SpringPrismProperties properties) {
+    SpringPrismProperties.Dashboard dashboard = properties.getDashboard();
+    return new PrismRuntimeMetrics(dashboard.getAuditRetention(), dashboard.getHistoryRetention());
   }
 
   @Bean
@@ -118,8 +119,9 @@ public class SpringPrismAutoConfiguration {
   MetricsController metricsController(
       PrismRuntimeMetrics prismRuntimeMetrics,
       @Qualifier("springPrismRulePacks") List<PrismRulePack> springPrismRulePacks,
-      PrismVault prismVault) {
-    return new MetricsController(prismRuntimeMetrics, springPrismRulePacks, prismVault);
+      PrismVault prismVault,
+      SpringPrismProperties properties) {
+    return new MetricsController(prismRuntimeMetrics, springPrismRulePacks, prismVault, properties);
   }
 
   @Bean
@@ -128,8 +130,10 @@ public class SpringPrismAutoConfiguration {
   PrismActuatorEndpoint prismActuatorEndpoint(
       PrismRuntimeMetrics prismRuntimeMetrics,
       @Qualifier("springPrismRulePacks") List<PrismRulePack> springPrismRulePacks,
-      PrismVault prismVault) {
-    return new PrismActuatorEndpoint(prismRuntimeMetrics, springPrismRulePacks, prismVault);
+      PrismVault prismVault,
+      SpringPrismProperties properties) {
+    return new PrismActuatorEndpoint(
+        prismRuntimeMetrics, springPrismRulePacks, prismVault, properties);
   }
 
   private static byte[] secretKey(SpringPrismProperties properties) {

--- a/prism-spring-boot-starter/src/main/java/io/github/catalin87/prism/boot/autoconfigure/SpringPrismProperties.java
+++ b/prism-spring-boot-starter/src/main/java/io/github/catalin87/prism/boot/autoconfigure/SpringPrismProperties.java
@@ -29,6 +29,9 @@ public class SpringPrismProperties {
   private static final String DEFAULT_SECRET = "spring-prism-change-me";
   private static final Duration DEFAULT_TTL = Duration.ofMinutes(30);
   private static final List<String> DEFAULT_LOCALES = List.of("UNIVERSAL");
+  private static final int DEFAULT_AUDIT_RETENTION = 12;
+  private static final int DEFAULT_HISTORY_RETENTION = 120;
+  private static final int DEFAULT_POLLING_SECONDS = 30;
 
   private boolean enabled = true;
   private boolean securityStrictMode;
@@ -37,6 +40,7 @@ public class SpringPrismProperties {
   private List<String> locales = new ArrayList<>(DEFAULT_LOCALES);
   private List<CustomRule> customRules = new ArrayList<>();
   private Set<String> disabledRules = new LinkedHashSet<>();
+  private Dashboard dashboard = new Dashboard();
 
   public boolean isEnabled() {
     return enabled;
@@ -108,6 +112,116 @@ public class SpringPrismProperties {
   public void setDisabledRules(Set<String> disabledRules) {
     this.disabledRules =
         disabledRules == null ? new LinkedHashSet<>() : new LinkedHashSet<>(disabledRules);
+  }
+
+  public Dashboard getDashboard() {
+    return dashboard;
+  }
+
+  public void setDashboard(Dashboard dashboard) {
+    this.dashboard = dashboard == null ? new Dashboard() : dashboard;
+  }
+
+  /** Externalized dashboard-specific configuration. */
+  public static class Dashboard {
+    private int auditRetention = DEFAULT_AUDIT_RETENTION;
+    private int historyRetention = DEFAULT_HISTORY_RETENTION;
+    private int defaultPollingSeconds = DEFAULT_POLLING_SECONDS;
+    private AlertThresholds alertThresholds = new AlertThresholds();
+
+    public int getAuditRetention() {
+      return auditRetention;
+    }
+
+    public void setAuditRetention(int auditRetention) {
+      this.auditRetention = auditRetention <= 0 ? DEFAULT_AUDIT_RETENTION : auditRetention;
+    }
+
+    public int getHistoryRetention() {
+      return historyRetention;
+    }
+
+    public void setHistoryRetention(int historyRetention) {
+      this.historyRetention = historyRetention <= 0 ? DEFAULT_HISTORY_RETENTION : historyRetention;
+    }
+
+    public int getDefaultPollingSeconds() {
+      return defaultPollingSeconds;
+    }
+
+    public void setDefaultPollingSeconds(int defaultPollingSeconds) {
+      this.defaultPollingSeconds =
+          defaultPollingSeconds < 0 ? DEFAULT_POLLING_SECONDS : defaultPollingSeconds;
+    }
+
+    public AlertThresholds getAlertThresholds() {
+      return alertThresholds;
+    }
+
+    public void setAlertThresholds(AlertThresholds alertThresholds) {
+      this.alertThresholds = alertThresholds == null ? new AlertThresholds() : alertThresholds;
+    }
+  }
+
+  /** Externalized dashboard alert thresholds. */
+  public static class AlertThresholds {
+    private double scanLatencyWarnMs = 25d;
+    private double scanLatencyCriticalMs = 75d;
+    private long tokenBacklogWarn = 5L;
+    private long tokenBacklogCritical = 20L;
+    private long detectionErrorWarn = 1L;
+    private long detectionErrorCritical = 5L;
+
+    public double getScanLatencyWarnMs() {
+      return scanLatencyWarnMs;
+    }
+
+    public void setScanLatencyWarnMs(double scanLatencyWarnMs) {
+      this.scanLatencyWarnMs = scanLatencyWarnMs <= 0 ? 25d : scanLatencyWarnMs;
+    }
+
+    public double getScanLatencyCriticalMs() {
+      return scanLatencyCriticalMs;
+    }
+
+    public void setScanLatencyCriticalMs(double scanLatencyCriticalMs) {
+      this.scanLatencyCriticalMs =
+          scanLatencyCriticalMs <= 0 ? 75d : Math.max(scanLatencyCriticalMs, scanLatencyWarnMs);
+    }
+
+    public long getTokenBacklogWarn() {
+      return tokenBacklogWarn;
+    }
+
+    public void setTokenBacklogWarn(long tokenBacklogWarn) {
+      this.tokenBacklogWarn = tokenBacklogWarn < 0 ? 5L : tokenBacklogWarn;
+    }
+
+    public long getTokenBacklogCritical() {
+      return tokenBacklogCritical;
+    }
+
+    public void setTokenBacklogCritical(long tokenBacklogCritical) {
+      this.tokenBacklogCritical =
+          tokenBacklogCritical < 0 ? 20L : Math.max(tokenBacklogCritical, tokenBacklogWarn);
+    }
+
+    public long getDetectionErrorWarn() {
+      return detectionErrorWarn;
+    }
+
+    public void setDetectionErrorWarn(long detectionErrorWarn) {
+      this.detectionErrorWarn = detectionErrorWarn < 0 ? 1L : detectionErrorWarn;
+    }
+
+    public long getDetectionErrorCritical() {
+      return detectionErrorCritical;
+    }
+
+    public void setDetectionErrorCritical(long detectionErrorCritical) {
+      this.detectionErrorCritical =
+          detectionErrorCritical < 0 ? 5L : Math.max(detectionErrorCritical, detectionErrorWarn);
+    }
   }
 
   /** Placeholder binding model for future property-defined detectors. */

--- a/prism-spring-boot-starter/src/test/java/io/github/catalin87/prism/boot/autoconfigure/SpringPrismAutoConfigurationTest.java
+++ b/prism-spring-boot-starter/src/test/java/io/github/catalin87/prism/boot/autoconfigure/SpringPrismAutoConfigurationTest.java
@@ -114,12 +114,26 @@ class SpringPrismAutoConfigurationTest {
   @Test
   void propertiesBindingSupportsTtlAndStrictMode() {
     contextRunner
-        .withPropertyValues("spring.prism.security-strict-mode=true", "spring.prism.ttl=45m")
+        .withPropertyValues(
+            "spring.prism.security-strict-mode=true",
+            "spring.prism.ttl=45m",
+            "spring.prism.dashboard.audit-retention=20",
+            "spring.prism.dashboard.history-retention=240",
+            "spring.prism.dashboard.default-polling-seconds=45",
+            "spring.prism.dashboard.alert-thresholds.scan-latency-warn-ms=40",
+            "spring.prism.dashboard.alert-thresholds.token-backlog-critical=30")
         .run(
             context -> {
               SpringPrismProperties properties = context.getBean(SpringPrismProperties.class);
               assertThat(properties.isSecurityStrictMode()).isTrue();
               assertThat(properties.getTtl()).isEqualTo(Duration.ofMinutes(45));
+              assertThat(properties.getDashboard().getAuditRetention()).isEqualTo(20);
+              assertThat(properties.getDashboard().getHistoryRetention()).isEqualTo(240);
+              assertThat(properties.getDashboard().getDefaultPollingSeconds()).isEqualTo(45);
+              assertThat(properties.getDashboard().getAlertThresholds().getScanLatencyWarnMs())
+                  .isEqualTo(40d);
+              assertThat(properties.getDashboard().getAlertThresholds().getTokenBacklogCritical())
+                  .isEqualTo(30L);
             });
   }
 
@@ -135,6 +149,8 @@ class SpringPrismAutoConfigurationTest {
               assertThat(properties.getTtl()).isEqualTo(Duration.ofMinutes(30));
               assertThat(properties.getAppSecret()).isEqualTo("spring-prism-change-me");
               assertThat(properties.getLocales()).containsExactly("UNIVERSAL");
+              assertThat(properties.getDashboard().getAuditRetention()).isEqualTo(12);
+              assertThat(properties.getDashboard().getHistoryRetention()).isEqualTo(120);
               assertThat(context.getBean(PrismVault.class)).isInstanceOf(DefaultPrismVault.class);
             });
   }
@@ -194,11 +210,15 @@ class SpringPrismAutoConfigurationTest {
           assertThat(snapshot.integrationMetrics())
               .extracting(IntegrationMetric::name)
               .contains("spring-ai", "langchain4j");
+          assertThat(snapshot.historyRollups())
+              .extracting(HistoryRollup::key)
+              .contains("recent", "5m", "15m", "1h");
           assertThat(snapshot.historySamples()).isNotEmpty();
           assertThat(snapshot.historyRetentionLimit()).isEqualTo(120);
           assertThat(snapshot.auditEvents()).isNotEmpty();
           assertThat(snapshot.auditRetentionLimit()).isEqualTo(12);
           assertThat(snapshot.tokenBacklog()).isGreaterThanOrEqualTo(0);
+          assertThat(snapshot.dashboardConfiguration().defaultPollingSeconds()).isEqualTo(30);
         });
   }
 

--- a/website/docs/architecture.md
+++ b/website/docs/architecture.md
@@ -40,8 +40,8 @@ The embedded observability surface.
 - **Packaging**: Static assets are served from `META-INF/resources/prism/` inside the dashboard jar.
 - **Data Source**: Reads the Prism runtime snapshot from `/actuator/prism` when Actuator is present and falls back to `/prism/metrics` otherwise.
 - **Verification**: Includes a bundled `/prism/?demo=1` fixture mode for visual checks without a live runtime.
-- **Current Scope**: Dashboard shell, top-redacted metrics, vault/runtime health, rule-pack activity bars, integration timing cards, alert and vault posture cards, entity drill-downs, server-side retained history charts, operational filters, polling/export controls, a masked recent-activity audit feed with filters, and a visual refraction-flow explainer.
-- **Operational Guidance**: The dashboard payload stays masked, but the routes remain operational endpoints and should be protected by the host application's normal security boundary in production.
+- **Current Scope**: Dashboard shell, top-redacted metrics, vault/runtime health, rule-pack activity bars, integration timing cards, threshold-aware alerts, vault posture cards, entity drill-downs, server-side retained history charts, rollup cards, operational filters, JSON/CSV/incident exports, a masked recent-activity audit feed with filters, and a visual refraction-flow explainer.
+- **Operational Guidance**: The dashboard payload stays masked, but the routes remain operational endpoints and should be protected by the host application's normal security boundary in production. Dashboard defaults and thresholds are configured centrally under `spring.prism.dashboard.*`.
 
 ## The Request Lifecycle
 

--- a/website/docs/dashboard.md
+++ b/website/docs/dashboard.md
@@ -23,15 +23,39 @@ If Actuator is not on the classpath, it falls back to:
 - Runtime pulse and tracked timer count
 - Rule-pack activity bars
 - Trend cards for leading pack, total detections, slowest timer, and audit retention
+- Server-side rollup cards for recent, 5 minute, 15 minute, and 1 hour windows
 - Integration drill-down cards for Spring AI and LangChain4j timing paths
-- Alert cards for detection errors, scan latency, token backlog, and vault mode
+- Threshold-aware alert cards for detection errors, scan latency, token backlog, and vault mode
 - Entity drill-down cards grouped by rule pack and detector type
 - Vault insight cards describing local vs Redis posture, shared-vs-local topology, and restore pressure
+- Admin cards showing current retention, polling, and alert-threshold settings
 - Masked recent-activity audit feed with action/source/limit filters
 - Server-side retained history charts for detections, errors, scan latency, and token backlog
-- Polling controls plus snapshot export
-- Operational filters for integration, rule pack, and entity type
+- Polling controls plus JSON, CSV, and incident-summary export
+- Operational filters for integration, rule pack, entity type, and trend window
 - Refraction-flow explainer
+
+## Dashboard configuration
+
+The embedded UI now reads its defaults and alert thresholds from `spring.prism.dashboard.*`:
+
+```yaml
+spring:
+  prism:
+    dashboard:
+      default-polling-seconds: 30
+      audit-retention: 12
+      history-retention: 120
+      alert-thresholds:
+        scan-latency-warn-ms: 25
+        scan-latency-critical-ms: 75
+        token-backlog-warn: 5
+        token-backlog-critical: 20
+        detection-error-warn: 1
+        detection-error-critical: 5
+```
+
+These values shape both the server-side snapshot and the UI rendering, which keeps the dashboard behavior truthful to the running app configuration.
 
 ## Live example integration
 
@@ -71,3 +95,13 @@ Demo mode loads the packaged `demo-metrics.json` fixture and keeps all values ma
 - Treat `/prism/`, `/prism/metrics`, and `/actuator/prism` as operational surfaces.
 - In production, protect them with your application authentication, reverse-proxy controls, or network policy.
 - Spring Prism keeps the payload masked, but the endpoints still expose meaningful operational metadata and should not be left broadly public.
+
+For Spring Security-based applications, a simple pattern is to require an operator role for the dashboard routes:
+
+```java
+http.authorizeHttpRequests(authorize -> authorize
+    .requestMatchers("/prism/**", "/actuator/prism").hasRole("PRISM_OPERATOR")
+    .anyRequest().authenticated());
+```
+
+If you do not use Spring Security, place the routes behind an internal gateway, VPN, or ingress rule instead.


### PR DESCRIPTION
## Summary
- add configurable dashboard retention, polling defaults, and alert thresholds under spring.prism.dashboard
- publish richer dashboard snapshot data including rollups, server-side config, and stronger vault posture details
- finish the embedded dashboard with trend-window controls, threshold-aware alerts, JSON/CSV/incident exports, and admin configuration cards
- document production protection guidance and wire example apps with explicit dashboard configuration defaults

## Validation
- mvn -Dmaven.repo.local=/tmp/spring-prism-m2 -pl prism-spring-boot-starter,prism-dashboard,prism-examples/spring-ai-example,prism-examples/langchain4j-example -am test
- npm run build
