### PR TITLE
ci: add weekly owasp cache warmup

### DIFF
--- a/.github/workflows/owasp-cache-warmup.yml
+++ b/.github/workflows/owasp-cache-warmup.yml
@@ -1,0 +1,55 @@
+name: Warm OWASP Dependency-Check Cache
+
+on:
+  schedule:
+    - cron: '0 3 * * 1'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  warm-dependency-check-cache:
+    name: Warm Dependency-Check Cache
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout Source Code
+        uses: actions/checkout@v4
+
+      - name: Provision JDK 21 (Temurin)
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Compute OWASP cache week
+        id: dependency-check-week
+        run: echo "week=$(date -u +%G-W%V)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache OWASP Dependency-Check data
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2/repository/org/owasp/dependency-check-data
+          key: ${{ runner.os }}-dependency-check-${{ steps.dependency-check-week.outputs.week }}
+          restore-keys: |
+            ${{ runner.os }}-dependency-check-
+
+      - name: Warm OWASP Dependency-Check database
+        env:
+          NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
+        run: |
+          if [ -z "$NVD_API_KEY" ]; then
+            echo "::warning title=OWASP Cache Warmup Skipped::Skipping dependency-check cache warmup because NVD_API_KEY is not configured."
+          else
+            mvn org.owasp:dependency-check-maven:update-only \
+              -DnvdApiKey=$NVD_API_KEY \
+              -DossIndexAnalyzerEnabled=false \
+              -DdataDirectory=$HOME/.m2/repository/org/owasp/dependency-check-data \
+              --batch-mode
+          fi


### PR DESCRIPTION
## Summary
- add a separate weekly and manual OWASP dependency-check cache warmup workflow
- reuse the same weekly cache key and data directory as the main CI pipeline
- keep the heavy NVD download out of normal PR validation as much as possible

## Notes
- the warmup runs every Monday at 03:00 UTC
- it uses the configured NVD API key when available

## Testing
- workflow YAML reviewed locally against the current pipeline cache path and key scheme