### PR TITLE
feat: add protocol-aware MCP payload handling

### DIFF
--- a/prism-mcp/src/main/java/io/github/catalin87/prism/mcp/PrismMcpPayloadSanitizer.java
+++ b/prism-mcp/src/main/java/io/github/catalin87/prism/mcp/PrismMcpPayloadSanitizer.java
@@ -15,6 +15,9 @@
  */
 package io.github.catalin87.prism.mcp;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.catalin87.prism.core.PiiCandidate;
 import io.github.catalin87.prism.core.PiiDetector;
 import io.github.catalin87.prism.core.PrismRulePack;
@@ -25,14 +28,23 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 /** Recursively sanitizes and restores textual values inside JSON-like MCP payloads. */
 public final class PrismMcpPayloadSanitizer {
 
   private static final Pattern TOKEN_PATTERN = Pattern.compile("<PRISM_[a-zA-Z0-9_-]+>");
+  private static final TypeReference<Map<String, Object>> MAP_TYPE = new TypeReference<>() {};
+  private static final TypeReference<List<Object>> LIST_TYPE = new TypeReference<>() {};
+  private static final Set<String> STRUCTURAL_STRING_KEYS =
+      Set.of("jsonrpc", "id", "method", "type", "role", "name", "uri", "mimeType", "model");
+  private static final Set<String> JSON_STRING_KEYS = Set.of("arguments", "structuredContent");
+
+  private final ObjectMapper objectMapper = new ObjectMapper();
 
   private final List<PrismRulePack> rulePacks;
   private final PrismVault vault;
@@ -72,13 +84,13 @@ public final class PrismMcpPayloadSanitizer {
   /** Returns a recursively sanitized copy of the outbound request payload. */
   public @NonNull Map<String, Object> sanitizeRequest(
       @NonNull Map<String, Object> payload, @NonNull String integration) {
-    return castMap(transformValue(payload, integration, true));
+    return castMap(transformValue(payload, integration, true, null));
   }
 
   /** Returns a recursively restored copy of the inbound response payload. */
   public @NonNull Map<String, Object> restoreResponse(
       @NonNull Map<String, Object> payload, @NonNull String integration) {
-    return castMap(transformValue(payload, integration, false));
+    return castMap(transformValue(payload, integration, false, null));
   }
 
   @SuppressWarnings("unchecked")
@@ -86,27 +98,62 @@ public final class PrismMcpPayloadSanitizer {
     return (Map<String, Object>) value;
   }
 
-  private Object transformValue(Object value, String integration, boolean outbound) {
+  private Object transformValue(
+      Object value, String integration, boolean outbound, @Nullable String fieldName) {
     if (value instanceof String text) {
+      if (fieldName != null && STRUCTURAL_STRING_KEYS.contains(fieldName)) {
+        return text;
+      }
+      if (fieldName != null && JSON_STRING_KEYS.contains(fieldName)) {
+        Object parsed = tryParseStructuredJson(text);
+        if (parsed != null) {
+          try {
+            return objectMapper.writeValueAsString(
+                transformValue(parsed, integration, outbound, fieldName));
+          } catch (JsonProcessingException exception) {
+            if (strictMode) {
+              throw new IllegalStateException(
+                  "Strict mode blocked Prism MCP processing after JSON serialization failure",
+                  exception);
+            }
+            return outbound
+                ? tokenizeString(text, integration)
+                : detokenizeString(text, integration);
+          }
+        }
+      }
       return outbound ? tokenizeString(text, integration) : detokenizeString(text, integration);
     }
     if (value instanceof Map<?, ?> map) {
       Map<String, Object> transformed = new LinkedHashMap<>();
       for (Map.Entry<?, ?> entry : map.entrySet()) {
-        transformed.put(
-            String.valueOf(entry.getKey()),
-            transformValue(entry.getValue(), integration, outbound));
+        String key = String.valueOf(entry.getKey());
+        transformed.put(key, transformValue(entry.getValue(), integration, outbound, key));
       }
       return transformed;
     }
     if (value instanceof List<?> list) {
       List<Object> transformed = new ArrayList<>(list.size());
       for (Object element : list) {
-        transformed.add(transformValue(element, integration, outbound));
+        transformed.add(transformValue(element, integration, outbound, fieldName));
       }
       return transformed;
     }
     return value;
+  }
+
+  private @Nullable Object tryParseStructuredJson(String text) {
+    String trimmed = text.trim();
+    if (!(trimmed.startsWith("{") || trimmed.startsWith("["))) {
+      return null;
+    }
+    try {
+      return trimmed.startsWith("{")
+          ? objectMapper.readValue(trimmed, MAP_TYPE)
+          : objectMapper.readValue(trimmed, LIST_TYPE);
+    } catch (JsonProcessingException exception) {
+      return null;
+    }
   }
 
   private String tokenizeString(String text, String integration) {

--- a/prism-mcp/src/test/java/io/github/catalin87/prism/mcp/PrismMcpPayloadSanitizerTest.java
+++ b/prism-mcp/src/test/java/io/github/catalin87/prism/mcp/PrismMcpPayloadSanitizerTest.java
@@ -114,6 +114,103 @@ class PrismMcpPayloadSanitizerTest {
         .hasMessageContaining("Strict mode blocked Prism MCP processing");
   }
 
+  @Test
+  void sanitizeJsonEncodedToolArguments() {
+    PrismMcpPayloadSanitizer sanitizer =
+        new PrismMcpPayloadSanitizer(List.of(new UniversalRulePack()), vault);
+
+    Map<String, Object> sanitized =
+        sanitizer.sanitizeRequest(
+            Map.of(
+                "jsonrpc",
+                "2.0",
+                "method",
+                "tools/call",
+                "params",
+                Map.of(
+                    "name",
+                    "lookupCustomer",
+                    "arguments",
+                    """
+                    {"email":"user@example.com","nested":{"phone":"+40 712 345 678"}}
+                    """)),
+            PrismMcpMetricsSink.MCP_STDIO_INTEGRATION);
+
+    @SuppressWarnings("unchecked")
+    Map<String, Object> params = (Map<String, Object>) sanitized.get("params");
+    String arguments = String.valueOf(params.get("arguments"));
+
+    assertThat(arguments).contains("<PRISM_EMAIL_").contains("<PRISM_PHONE_NUMBER_");
+    assertThat(arguments).doesNotContain("user@example.com").doesNotContain("+40 712 345 678");
+    assertThat(params.get("name")).isEqualTo("lookupCustomer");
+    assertThat(sanitized.get("method")).isEqualTo("tools/call");
+  }
+
+  @Test
+  void sanitizeMessageContentWithoutTouchingProtocolFields() {
+    PrismMcpPayloadSanitizer sanitizer =
+        new PrismMcpPayloadSanitizer(List.of(new UniversalRulePack()), vault);
+
+    Map<String, Object> sanitized =
+        sanitizer.sanitizeRequest(
+            Map.of(
+                "jsonrpc",
+                "2.0",
+                "method",
+                "sampling/createMessage",
+                "params",
+                Map.of(
+                    "model",
+                    "gpt-5.4",
+                    "messages",
+                    List.of(
+                        Map.of(
+                            "role",
+                            "user",
+                            "content",
+                            List.of(
+                                Map.of("type", "text", "text", "Email user@example.com"),
+                                Map.of("type", "text", "text", "Call +40 712 345 678")))))),
+            PrismMcpMetricsSink.MCP_STREAMABLE_HTTP_INTEGRATION);
+
+    assertThat(String.valueOf(sanitized))
+        .contains("<PRISM_EMAIL_")
+        .contains("<PRISM_PHONE_NUMBER_")
+        .contains("sampling/createMessage")
+        .contains("role=user")
+        .contains("type=text")
+        .doesNotContain("user@example.com")
+        .doesNotContain("+40 712 345 678");
+  }
+
+  @Test
+  void restoreStructuredContentAndTextBlocks() {
+    PrismMcpPayloadSanitizer sanitizer =
+        new PrismMcpPayloadSanitizer(List.of(new UniversalRulePack()), vault);
+
+    String emailToken = vault.tokenize("user@example.com", "EMAIL").key();
+    String phoneToken = vault.tokenize("+40 712 345 678", "PHONE_NUMBER").key();
+
+    Map<String, Object> restored =
+        sanitizer.restoreResponse(
+            Map.of(
+                "jsonrpc",
+                "2.0",
+                "result",
+                Map.of(
+                    "content",
+                    List.of(Map.of("type", "text", "text", "Handled " + emailToken)),
+                    "structuredContent",
+                    "{\"phone\":\"" + phoneToken + "\"}")),
+            PrismMcpMetricsSink.MCP_STDIO_INTEGRATION);
+
+    assertThat(String.valueOf(restored))
+        .contains("user@example.com")
+        .contains("+40 712 345 678")
+        .doesNotContain("<PRISM_EMAIL_")
+        .doesNotContain("<PRISM_PHONE_NUMBER_");
+  }
+
   private static final class FailingRulePack implements PrismRulePack {
     @Override
     public @NonNull List<PiiDetector> getDetectors() {

--- a/website/docs/architecture.md
+++ b/website/docs/architecture.md
@@ -42,6 +42,7 @@ The MCP client protection layer.
 - **Scope**: Protects the Java application in the MCP client role first by sanitizing outbound JSON-like request payloads and restoring Prism tokens in inbound MCP results.
 - **Transport Coverage**: Supports local subprocess `stdio` and hosted `Streamable HTTP` transports. Docker remains a deployment detail on top of the same transport contract.
 - **Structured Payload Support**: Recursively walks strings inside maps, lists, prompt fields, tool arguments, and textual results without introducing Spring dependencies into the module.
+- **Protocol-Aware Support**: Handles common MCP request/result shapes more explicitly, including tool argument payloads, message content blocks, and JSON-encoded structured argument values.
 - **Streaming Foundation**: Uses a dedicated event-stream parser so `Streamable HTTP` responses can tolerate multi-line `data:` events and terminal markers such as `[DONE]`.
 - **Server Groundwork**: Includes a reusable server interceptor foundation so later MCP server-role support can share the same payload sanitization and restoration rules.
 

--- a/website/docs/mcp.md
+++ b/website/docs/mcp.md
@@ -9,6 +9,7 @@ The current MCP support lives in `prism-mcp` and focuses on the client boundary 
 - outbound payload sanitization before JSON-RPC requests leave the trusted application
 - inbound token restoration after MCP responses return
 - recursive walking of strings inside nested maps, lists, prompt fields, tool arguments, and textual result payloads
+- protocol-aware handling for common MCP shapes such as tool arguments, message content blocks, and JSON-encoded structured argument payloads
 - stronger `Streamable HTTP` event parsing for multi-line `data:` frames and `[DONE]` style trailers
 - fail-open behavior by default, with strict mode available through starter properties
 - runtime metrics aligned with the existing Spring AI and LangChain4j integrations


### PR DESCRIPTION
## Summary
- add protocol-aware MCP payload handling on top of the existing recursive sanitizer
- parse JSON-encoded tool arguments and structured content payload strings when present
- leave structural protocol fields untouched while still sanitizing real text-bearing MCP content

## Testing
- mvn -Dmaven.repo.local=/tmp/spring-prism-m2 -pl prism-mcp -am test -DskipITs
- cd website && npm run build