### PR TITLE
ci: aggregate OWASP scan across reactor

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -82,7 +82,7 @@ jobs:
             echo "::warning title=CVE Scanner Disabled::Skipping OWASP dependency-check. Please add NVD_API_KEY to GitHub Secrets to prevent 429 API rate limits!"
           else
             set +e
-            mvn org.owasp:dependency-check-maven:check \
+            mvn org.owasp:dependency-check-maven:aggregate \
               -DfailBuildOnCVSS=7 \
               -DnvdApiKey=$NVD_API_KEY \
               -DossIndexAnalyzerEnabled=false \


### PR DESCRIPTION
## Summary
- switch the OWASP GitHub Actions step from per-module check execution to reactor aggregate scanning
- keep the same CVSS threshold and cached data directory
- avoid false CI failures when reactor modules depend on unreleased local snapshots

## Why
The direct dependency-check goal was resolving intra-reactor snapshots like published artifacts during CI and failing before MCP modules were even evaluated.
