### PR TITLE
feat: polish MCP observability signals

### DIFF
--- a/prism-dashboard/src/main/resources/META-INF/resources/prism/app.js
+++ b/prism-dashboard/src/main/resources/META-INF/resources/prism/app.js
@@ -394,7 +394,8 @@ function renderIntegrationSummary(metrics) {
   }
 
   integrations.forEach(integration => {
-    const title = integration.name === "spring-ai" ? "Spring AI" : "LangChain4j";
+    const title = integrationLabel(integration.name);
+    const scanSamples = integration.scan?.samples ?? 0;
     const card = document.createElement("article");
     card.className = "integration-card";
     card.innerHTML = `
@@ -402,6 +403,7 @@ function renderIntegrationSummary(metrics) {
       <strong>${formatMilliseconds(integration.scan)}</strong>
       <span>Scan avg</span>
       <dl class="mini-metrics">
+        <div><dt>Samples</dt><dd>${scanSamples}</dd></div>
         <div><dt>Tokenize</dt><dd>${formatMilliseconds(integration.tokenize)}</dd></div>
         <div><dt>Detokenize</dt><dd>${formatMilliseconds(integration.detokenize)}</dd></div>
       </dl>
@@ -418,8 +420,7 @@ function renderAlerts(metrics) {
   const container = document.getElementById("alert-cards");
   container.replaceChildren();
 
-  const scanMetric = metrics.durationMetrics?.["spring-ai:scan"]
-      ?? metrics.durationMetrics?.["langchain4j:scan"];
+  const scanMetric = highestScanMetric(metrics.integrationMetrics ?? []);
   const scanMs = averageMilliseconds(scanMetric);
   const tokenGap = metrics.tokenBacklog ?? Math.max(0, (metrics.tokenizedCount ?? 0) - (metrics.detokenizedCount ?? 0));
   const errorCount = metrics.detectionErrorCount ?? 0;
@@ -468,6 +469,28 @@ function renderAlerts(metrics) {
     `;
     container.append(card);
   });
+}
+
+function highestScanMetric(integrationMetrics) {
+  return integrationMetrics
+      .map(integration => integration.scan)
+      .filter(metric => metric && (metric.samples ?? 0) > 0)
+      .sort((left, right) => averageMilliseconds(right) - averageMilliseconds(left))[0];
+}
+
+function integrationLabel(name) {
+  switch (name) {
+    case "spring-ai":
+      return "Spring AI";
+    case "langchain4j":
+      return "LangChain4j";
+    case "mcp-stdio":
+      return "MCP Stdio";
+    case "mcp-streamable-http":
+      return "MCP Streamable HTTP";
+    default:
+      return name;
+  }
 }
 
 function renderEntityDrilldowns(metrics) {

--- a/prism-spring-boot-starter/src/main/java/io/github/catalin87/prism/boot/autoconfigure/PrismRuntimeMetrics.java
+++ b/prism-spring-boot-starter/src/main/java/io/github/catalin87/prism/boot/autoconfigure/PrismRuntimeMetrics.java
@@ -159,7 +159,8 @@ public class PrismRuntimeMetrics
             Instant.now().toString(),
             totalDetections,
             detectionErrors,
-            averageMilliseconds("spring-ai:scan", "langchain4j:scan"),
+            averageMilliseconds(
+                "spring-ai:scan", "langchain4j:scan", "mcp-stdio:scan", "mcp-streamable-http:scan"),
             tokenized,
             detokenized,
             Math.max(0, tokenized - detokenized),

--- a/website/docs/mcp.md
+++ b/website/docs/mcp.md
@@ -13,6 +13,7 @@ The current MCP support lives in `prism-mcp` and focuses on the client boundary 
 - stronger `Streamable HTTP` event parsing for multi-line `data:` frames, progress events, request-id correlation, and `[DONE]` style trailers
 - fail-open behavior by default, with strict mode available through starter properties
 - runtime metrics aligned with the existing Spring AI and LangChain4j integrations
+- dashboard timing cards and history rollups now include MCP transport activity instead of treating MCP traffic as invisible background load
 
 ## Supported Transports
 


### PR DESCRIPTION
## Summary
- include MCP timings in retained dashboard history and integration cards
- surface MCP stdio and Streamable HTTP explicitly in runtime summaries
- calculate latency alerts from the slowest active integration, including MCP traffic

## Testing
- mvn -Dmaven.repo.local=/tmp/spring-prism-m2 -pl prism-spring-boot-starter,prism-dashboard -am test -DskipITs