### PR TITLE
feat: redesign dashboard and add privacy score

### DIFF
--- a/prism-dashboard/src/main/resources/META-INF/resources/prism/app.js
+++ b/prism-dashboard/src/main/resources/META-INF/resources/prism/app.js
@@ -28,6 +28,19 @@ const auditSourceFilter = document.getElementById("audit-source-filter");
 const auditLimitFilter = document.getElementById("audit-limit-filter");
 const auditRetentionNote = document.getElementById("audit-retention-note");
 const historyRetentionNote = document.getElementById("history-retention-note");
+const privacyScoreValue = document.getElementById("privacy-score-value");
+const privacyScoreRing = document.getElementById("privacy-score-ring");
+const privacyScoreWindow = document.getElementById("privacy-score-window");
+const privacyScoreExplanation = document.getElementById("privacy-score-explanation");
+const privacyCoverageScore = document.getElementById("privacy-coverage-score");
+const privacyCoverageBar = document.getElementById("privacy-coverage-bar");
+const privacyCoverageDetail = document.getElementById("privacy-coverage-detail");
+const privacyReliabilityScore = document.getElementById("privacy-reliability-score");
+const privacyReliabilityBar = document.getElementById("privacy-reliability-bar");
+const privacyReliabilityDetail = document.getElementById("privacy-reliability-detail");
+const privacyPostureScore = document.getElementById("privacy-posture-score");
+const privacyPostureBar = document.getElementById("privacy-posture-bar");
+const privacyPostureDetail = document.getElementById("privacy-posture-detail");
 
 let currentMetrics = null;
 let currentEndpoint = null;
@@ -127,6 +140,13 @@ function formatMilliseconds(durationMetric) {
     return "0 ms";
   }
   return `${(durationMetric.averageNanos / 1_000_000).toFixed(2)} ms`;
+}
+
+function setScoreBar(element, score) {
+  if (!element) {
+    return;
+  }
+  element.style.width = `${Math.max(0, Math.min(100, score))}%`;
 }
 
 function averageMilliseconds(durationMetric) {
@@ -261,6 +281,32 @@ function renderTopDetections(metrics) {
     item.append(label, value);
     topList.append(item);
   });
+}
+
+function renderPrivacyScore(metrics) {
+  const privacyScore = metrics.privacyScore;
+  if (!privacyScore) {
+    privacyScoreValue.textContent = "0";
+    privacyScoreRing.style.setProperty("--score", "0");
+    return;
+  }
+
+  privacyScoreValue.textContent = `${privacyScore.score ?? 0}`;
+  privacyScoreRing.style.setProperty("--score", `${privacyScore.score ?? 0}`);
+  privacyScoreWindow.textContent = privacyScore.windowLabel ?? "Last 60 minutes";
+  privacyScoreExplanation.textContent = privacyScore.explanation ?? "";
+
+  privacyCoverageScore.textContent = `${privacyScore.coverage?.score ?? 0}%`;
+  setScoreBar(privacyCoverageBar, privacyScore.coverage?.score ?? 0);
+  privacyCoverageDetail.textContent = privacyScore.coverage?.detail ?? "";
+
+  privacyReliabilityScore.textContent = `${privacyScore.reliability?.score ?? 0}%`;
+  setScoreBar(privacyReliabilityBar, privacyScore.reliability?.score ?? 0);
+  privacyReliabilityDetail.textContent = privacyScore.reliability?.detail ?? "";
+
+  privacyPostureScore.textContent = `${privacyScore.posture?.score ?? 0}%`;
+  setScoreBar(privacyPostureBar, privacyScore.posture?.score ?? 0);
+  privacyPostureDetail.textContent = privacyScore.posture?.detail ?? "";
 }
 
 function renderRulePackMetrics(rulePackMetrics) {
@@ -667,8 +713,7 @@ function healthSignal(metrics) {
   if ((metrics.detectionErrorCount ?? 0) > 0) {
     return "Attention";
   }
-  const scanMetric = metrics.durationMetrics?.["spring-ai:scan"]
-      ?? metrics.durationMetrics?.["langchain4j:scan"];
+  const scanMetric = highestScanMetric(metrics.integrationMetrics ?? []);
   if (averageMilliseconds(scanMetric) >= thresholds.scanLatencyCriticalMs) {
     return "Critical";
   }
@@ -806,8 +851,7 @@ function renderMetrics(endpoint, metrics) {
   currentEndpoint = endpoint;
   initializePollingFromMetrics(metrics);
 
-  const scanMetric = metrics.durationMetrics?.["spring-ai:scan"]
-      ?? metrics.durationMetrics?.["langchain4j:scan"];
+  const scanMetric = highestScanMetric(metrics.integrationMetrics ?? []);
 
   document.getElementById("vault-type").textContent = metrics.vaultType || "-";
   document.getElementById("tokenized-count").textContent = `${metrics.tokenizedCount ?? 0}`;
@@ -821,6 +865,7 @@ function renderMetrics(endpoint, metrics) {
       `${Object.keys(metrics.durationMetrics ?? {}).length}`;
   document.getElementById("endpoint-used").textContent = endpoint;
 
+  renderPrivacyScore(metrics);
   updateOperationalFilters(metrics);
   renderTopDetections(metrics);
   renderRulePackMetrics(metrics.rulePackMetrics ?? []);

--- a/prism-dashboard/src/main/resources/META-INF/resources/prism/demo-metrics.json
+++ b/prism-dashboard/src/main/resources/META-INF/resources/prism/demo-metrics.json
@@ -1,7 +1,27 @@
 {
-  "tokenizedCount": 21,
-  "detokenizedCount": 19,
+  "tokenizedCount": 34,
+  "detokenizedCount": 31,
   "detectionErrorCount": 1,
+  "privacyScore": {
+    "score": 92,
+    "windowLabel": "Last 60 minutes",
+    "explanation": "Based on protected activity, runtime reliability, and deployment posture in the last 60 minutes.",
+    "coverage": {
+      "label": "Coverage",
+      "score": 90,
+      "detail": "18 protected event(s) observed in the active window."
+    },
+    "reliability": {
+      "label": "Reliability",
+      "score": 94,
+      "detail": "No recent detector, vault, or restore errors reduced the score."
+    },
+    "posture": {
+      "label": "Posture",
+      "score": 91,
+      "detail": "strict mode on, Redis-backed shared vault, custom app secret configured, and token backlog is within the normal band."
+    }
+  },
   "detectionCounts": {
     "UNIVERSAL:EMAIL": 9,
     "UNIVERSAL:PHONE": 4,
@@ -19,10 +39,25 @@
       "totalNanos": 86000000,
       "averageNanos": 6142857
     },
+    "langchain4j:scan": {
+      "samples": 8,
+      "totalNanos": 78000000,
+      "averageNanos": 9750000
+    },
     "langchain4j:vault-detokenize": {
-      "samples": 5,
+      "samples": 8,
       "totalNanos": 43000000,
-      "averageNanos": 8600000
+      "averageNanos": 5375000
+    },
+    "mcp-stdio:scan": {
+      "samples": 5,
+      "totalNanos": 49000000,
+      "averageNanos": 9800000
+    },
+    "mcp-streamable-http:scan": {
+      "samples": 3,
+      "totalNanos": 36000000,
+      "averageNanos": 12000000
     }
   },
   "rulePackMetrics": [
@@ -37,30 +72,183 @@
       "totalDetections": 5
     }
   ],
+  "entityMetrics": [
+    {
+      "rulePackName": "UNIVERSAL",
+      "entityType": "EMAIL",
+      "detections": 9
+    },
+    {
+      "rulePackName": "UNIVERSAL",
+      "entityType": "PHONE",
+      "detections": 4
+    },
+    {
+      "rulePackName": "EUROPE",
+      "entityType": "IBAN",
+      "detections": 3
+    },
+    {
+      "rulePackName": "EUROPE",
+      "entityType": "PESEL",
+      "detections": 2
+    }
+  ],
+  "integrationMetrics": [
+    {
+      "name": "spring-ai",
+      "scan": {
+        "samples": 14,
+        "totalNanos": 104000000,
+        "averageNanos": 7428571
+      },
+      "tokenize": {
+        "samples": 14,
+        "totalNanos": 86000000,
+        "averageNanos": 6142857
+      },
+      "detokenize": null
+    },
+    {
+      "name": "langchain4j",
+      "scan": {
+        "samples": 8,
+        "totalNanos": 78000000,
+        "averageNanos": 9750000
+      },
+      "tokenize": null,
+      "detokenize": {
+        "samples": 8,
+        "totalNanos": 43000000,
+        "averageNanos": 5375000
+      }
+    },
+    {
+      "name": "mcp-stdio",
+      "scan": {
+        "samples": 5,
+        "totalNanos": 49000000,
+        "averageNanos": 9800000
+      },
+      "tokenize": null,
+      "detokenize": null
+    },
+    {
+      "name": "mcp-streamable-http",
+      "scan": {
+        "samples": 3,
+        "totalNanos": 36000000,
+        "averageNanos": 12000000
+      },
+      "tokenize": null,
+      "detokenize": null
+    }
+  ],
+  "historySamples": [
+    {
+      "capturedAt": "2026-03-23T15:12:00Z",
+      "totalDetections": 4,
+      "detectionErrors": 0,
+      "scanMilliseconds": 6.2,
+      "tokenizedCount": 6,
+      "detokenizedCount": 5,
+      "tokenBacklog": 1,
+      "vaultType": "RedisPrismVault"
+    },
+    {
+      "capturedAt": "2026-03-23T15:26:00Z",
+      "totalDetections": 8,
+      "detectionErrors": 0,
+      "scanMilliseconds": 7.9,
+      "tokenizedCount": 13,
+      "detokenizedCount": 12,
+      "tokenBacklog": 1,
+      "vaultType": "RedisPrismVault"
+    },
+    {
+      "capturedAt": "2026-03-23T15:41:00Z",
+      "totalDetections": 13,
+      "detectionErrors": 1,
+      "scanMilliseconds": 9.4,
+      "tokenizedCount": 22,
+      "detokenizedCount": 20,
+      "tokenBacklog": 2,
+      "vaultType": "RedisPrismVault"
+    },
+    {
+      "capturedAt": "2026-03-23T15:58:00Z",
+      "totalDetections": 18,
+      "detectionErrors": 1,
+      "scanMilliseconds": 8.1,
+      "tokenizedCount": 34,
+      "detokenizedCount": 31,
+      "tokenBacklog": 3,
+      "vaultType": "RedisPrismVault"
+    }
+  ],
+  "historyRollups": [
+    {
+      "key": "recent",
+      "label": "Recent",
+      "sampleCount": 4,
+      "latestDetections": 18,
+      "errorEvents": 1,
+      "averageScanMilliseconds": 7.9,
+      "peakTokenBacklog": 3
+    },
+    {
+      "key": "5m",
+      "label": "5 minutes",
+      "sampleCount": 1,
+      "latestDetections": 18,
+      "errorEvents": 1,
+      "averageScanMilliseconds": 8.1,
+      "peakTokenBacklog": 3
+    },
+    {
+      "key": "15m",
+      "label": "15 minutes",
+      "sampleCount": 2,
+      "latestDetections": 18,
+      "errorEvents": 1,
+      "averageScanMilliseconds": 8.75,
+      "peakTokenBacklog": 3
+    },
+    {
+      "key": "1h",
+      "label": "1 hour",
+      "sampleCount": 4,
+      "latestDetections": 18,
+      "errorEvents": 1,
+      "averageScanMilliseconds": 7.9,
+      "peakTokenBacklog": 3
+    }
+  ],
+  "historyRetentionLimit": 120,
   "auditEvents": [
     {
-      "timestamp": "2026-03-22T20:52:41Z",
+      "timestamp": "2026-03-23T15:58:21Z",
       "action": "detokenized",
       "subject": "PRISM_TOKEN",
       "count": 2,
       "source": "runtime"
     },
     {
-      "timestamp": "2026-03-22T20:51:57Z",
+      "timestamp": "2026-03-23T15:57:57Z",
       "action": "detected",
       "subject": "EMAIL",
       "count": 3,
       "source": "UNIVERSAL"
     },
     {
-      "timestamp": "2026-03-22T20:50:15Z",
+      "timestamp": "2026-03-23T15:56:15Z",
       "action": "detected",
       "subject": "IBAN",
       "count": 1,
       "source": "EUROPE"
     },
     {
-      "timestamp": "2026-03-22T20:49:48Z",
+      "timestamp": "2026-03-23T15:55:48Z",
       "action": "error",
       "subject": "PHONE",
       "count": 1,
@@ -72,5 +260,20 @@
     "UNIVERSAL",
     "EUROPE"
   ],
-  "vaultType": "DefaultPrismVault"
+  "vaultType": "RedisPrismVault",
+  "distributedVault": true,
+  "tokenBacklog": 3,
+  "dashboardConfiguration": {
+    "auditRetentionLimit": 12,
+    "historyRetentionLimit": 120,
+    "defaultPollingSeconds": 30,
+    "alertThresholds": {
+      "scanLatencyWarnMs": 25,
+      "scanLatencyCriticalMs": 75,
+      "tokenBacklogWarn": 5,
+      "tokenBacklogCritical": 20,
+      "detectionErrorWarn": 1,
+      "detectionErrorCritical": 5
+    }
+  }
 }

--- a/prism-dashboard/src/main/resources/META-INF/resources/prism/index.html
+++ b/prism-dashboard/src/main/resources/META-INF/resources/prism/index.html
@@ -13,9 +13,8 @@
           <p class="eyebrow">Spring Prism Dashboard</p>
           <h1>Operate Prism like a real privacy control plane.</h1>
           <p class="hero-copy">
-            Watch redaction traffic, vault posture, trend rollups, and alert thresholds without
-            exposing raw PII. The dashboard reads the runtime snapshot published by Spring Prism
-            and keeps every visible view aggregate or masked.
+            Track live protection posture, masked audit evidence, and runtime thresholds without
+            exposing raw PII.
           </p>
           <div class="hero-actions">
             <span id="mode-pill" class="mode-pill">Live mode</span>
@@ -49,10 +48,10 @@
           <label>
             Trend Window
             <select id="history-window">
-              <option value="ALL" selected>All retained</option>
+              <option value="ALL">All retained</option>
               <option value="5m">Last 5 minutes</option>
               <option value="15m">Last 15 minutes</option>
-              <option value="1h">Last hour</option>
+              <option value="1h" selected>Last hour</option>
             </select>
           </label>
           <label>
@@ -73,6 +72,18 @@
               <option value="ALL">All</option>
             </select>
           </label>
+          <label>
+            Policy
+            <select id="policy-filter" disabled>
+              <option>All</option>
+            </select>
+          </label>
+          <label>
+            Priority
+            <select id="priority-filter" disabled>
+              <option>All</option>
+            </select>
+          </label>
           <div class="ops-actions">
             <button id="polling-toggle" class="secondary-button" type="button">Pause Polling</button>
             <button id="export-button" class="secondary-button" type="button">Export JSON</button>
@@ -89,23 +100,56 @@
       </section>
 
       <section id="cards-grid" class="cards-grid hidden">
-        <article class="panel metric-card">
-          <p class="label">Vault Health</p>
-          <h2 id="vault-type">-</h2>
-          <dl class="metric-list">
+        <article class="panel score-panel">
+          <div class="panel-header compact">
             <div>
-              <dt>Tokenized</dt>
-              <dd id="tokenized-count">0</dd>
+              <p class="label">Global Privacy Score</p>
+              <h2>Live protection posture</h2>
             </div>
-            <div>
-              <dt>Detokenized</dt>
-              <dd id="detokenized-count">0</dd>
+            <span id="privacy-score-window" class="score-window">Last 60 minutes</span>
+          </div>
+          <div class="score-hero">
+            <div class="score-ring-shell">
+              <div id="privacy-score-ring" class="score-ring" style="--score: 0">
+                <div class="score-ring-core">
+                  <strong id="privacy-score-value">0</strong>
+                  <span>Safety</span>
+                </div>
+              </div>
             </div>
-            <div>
-              <dt>Detection Errors</dt>
-              <dd id="error-count">0</dd>
+            <div class="score-copy">
+              <p id="privacy-score-explanation" class="score-explanation">
+                Based on protected activity, runtime reliability, and deployment posture in the
+                last 60 minutes.
+              </p>
+              <div class="score-breakdown">
+                <article class="score-breakdown-card">
+                  <div class="score-breakdown-header">
+                    <span>Coverage</span>
+                    <strong id="privacy-coverage-score">0%</strong>
+                  </div>
+                  <div class="score-bar"><span id="privacy-coverage-bar"></span></div>
+                  <p id="privacy-coverage-detail">Waiting for recent protected traffic.</p>
+                </article>
+                <article class="score-breakdown-card">
+                  <div class="score-breakdown-header">
+                    <span>Reliability</span>
+                    <strong id="privacy-reliability-score">0%</strong>
+                  </div>
+                  <div class="score-bar"><span id="privacy-reliability-bar"></span></div>
+                  <p id="privacy-reliability-detail">Runtime error posture is still warming up.</p>
+                </article>
+                <article class="score-breakdown-card">
+                  <div class="score-breakdown-header">
+                    <span>Posture</span>
+                    <strong id="privacy-posture-score">0%</strong>
+                  </div>
+                  <div class="score-bar"><span id="privacy-posture-bar"></span></div>
+                  <p id="privacy-posture-detail">Deployment posture details will appear here.</p>
+                </article>
+              </div>
             </div>
-          </dl>
+          </div>
         </article>
 
         <article class="panel metric-card">
@@ -119,24 +163,40 @@
           <h2 id="scan-latency">0 ms</h2>
           <dl class="metric-list">
             <div>
-              <dt>Health Signal</dt>
-              <dd id="health-signal">-</dd>
+              <dt>Tokenized</dt>
+              <dd id="tokenized-count">0</dd>
             </div>
             <div>
-              <dt>Active Rule Packs</dt>
-              <dd id="rule-packs">-</dd>
+              <dt>Detokenized</dt>
+              <dd id="detokenized-count">0</dd>
+            </div>
+            <div>
+              <dt>Detection errors</dt>
+              <dd id="error-count">0</dd>
+            </div>
+            <div>
+              <dt>Vault mode</dt>
+              <dd id="vault-type">-</dd>
             </div>
             <div>
               <dt>Polling</dt>
               <dd id="polling-mode">-</dd>
             </div>
             <div>
-              <dt>Tracked Timers</dt>
+              <dt>Tracked timers</dt>
               <dd id="timer-count">0</dd>
             </div>
             <div>
-              <dt>Preferred Endpoint</dt>
+              <dt>Rule packs</dt>
+              <dd id="rule-packs">-</dd>
+            </div>
+            <div>
+              <dt>Preferred endpoint</dt>
               <dd id="endpoint-used">-</dd>
+            </div>
+            <div>
+              <dt>Health signal</dt>
+              <dd id="health-signal">-</dd>
             </div>
           </dl>
         </article>
@@ -144,44 +204,38 @@
 
       <section id="analytics-grid" class="analytics-grid hidden">
         <article class="panel metric-card">
+          <p class="label">Runtime Checkpoints</p>
+          <h2>Control-plane snapshots</h2>
+          <div id="trend-cards" class="trend-grid"></div>
+        </article>
+
+        <article class="panel metric-card">
+          <p class="label">Thresholds</p>
+          <h2>Operational boundaries</h2>
+          <div id="alert-cards" class="alert-grid"></div>
+        </article>
+
+        <article class="panel metric-card">
+          <p class="label">Integrations</p>
+          <h2>Runtime timing posture</h2>
+          <div id="integration-summary" class="integration-grid"></div>
+        </article>
+
+        <article class="panel metric-card">
           <p class="label">Rule Pack Activity</p>
           <h2>Locale-aware coverage</h2>
           <div id="rule-pack-metrics" class="bars-list"></div>
         </article>
 
         <article class="panel metric-card">
-          <p class="label">Trend Cards</p>
-          <h2>Runtime checkpoints</h2>
-          <div id="trend-cards" class="trend-grid"></div>
-        </article>
-
-        <article class="panel metric-card">
-          <p class="label">Rollups</p>
-          <h2>Server-side trend windows</h2>
-          <div id="rollup-cards" class="rollup-grid"></div>
-        </article>
-
-        <article class="panel metric-card">
-          <p class="label">Alerts</p>
-          <h2>Operational thresholds</h2>
-          <div id="alert-cards" class="alert-grid"></div>
-        </article>
-
-        <article class="panel metric-card">
-          <p class="label">Integrations</p>
-          <h2>Spring AI vs LangChain4j</h2>
-          <div id="integration-summary" class="integration-grid"></div>
-        </article>
-
-        <article class="panel metric-card">
-          <p class="label">Entities</p>
-          <h2>Detector drill-downs</h2>
+          <p class="label">Entity Drill-downs</p>
+          <h2>Detector hotspots</h2>
           <div id="entity-drilldowns" class="entity-grid"></div>
         </article>
 
         <article class="panel metric-card">
-          <p class="label">Vault Mode</p>
-          <h2>Current storage posture</h2>
+          <p class="label">Vault Posture</p>
+          <h2>Storage and restore pressure</h2>
           <div id="vault-insights" class="vault-grid"></div>
         </article>
 
@@ -192,8 +246,18 @@
         </article>
 
         <article class="panel metric-card">
-          <p class="label">Audit Log</p>
-          <h2>Masked recent activity</h2>
+          <p class="label">Rollups</p>
+          <h2>Server-side trend windows</h2>
+          <div id="rollup-cards" class="rollup-grid"></div>
+        </article>
+
+        <article class="panel metric-card audit-panel">
+          <div class="panel-header compact">
+            <div>
+              <p class="label">Masked Recent Activity</p>
+              <h2>Audit-friendly operational view</h2>
+            </div>
+          </div>
           <div class="audit-toolbar">
             <label>
               Action
@@ -225,8 +289,8 @@
       <section id="history-panel" class="panel history-panel hidden">
         <div class="panel-header">
           <div>
-            <p class="label">History</p>
-            <h2>Recent runtime changes</h2>
+            <p class="label">Runtime History</p>
+            <h2>Recent control-plane movement</h2>
           </div>
           <p id="history-retention-note" class="history-note"></p>
         </div>
@@ -254,37 +318,36 @@
         <div class="panel-header">
           <div>
             <p class="label">Refraction Flow</p>
-            <h2>How Prism protects sensitive prompts</h2>
+            <h2>How Spring Prism protects sensitive prompts</h2>
           </div>
         </div>
         <div class="flow-grid">
-          <div class="flow-step">
+          <article class="flow-step">
             <span>1</span>
-            <strong>App sends prompt</strong>
-            <p>User text still contains raw PII at this point.</p>
-          </div>
+            <strong>Scan</strong>
+            <p>Prism intercepts outbound prompts, tools, or MCP payloads before they leave the trusted boundary.</p>
+          </article>
           <div class="flow-arrow">→</div>
-          <div class="flow-step">
+          <article class="flow-step">
             <span>2</span>
-            <strong>Prism tokenizes PII</strong>
-            <p>The vault stores the original value and signs a Prism token.</p>
-          </div>
+            <strong>Redact</strong>
+            <p>Detected PII is replaced with HMAC-backed Prism tokens that external systems cannot reverse.</p>
+          </article>
           <div class="flow-arrow">→</div>
-          <div class="flow-step">
+          <article class="flow-step">
             <span>3</span>
-            <strong>AI model sees token only</strong>
-            <p>No raw email, card, SSN, phone, or regional identifier leaves the app.</p>
-          </div>
+            <strong>Vault</strong>
+            <p>Original values remain inside the local or Redis-backed Prism vault, with bounded retention.</p>
+          </article>
           <div class="flow-arrow">→</div>
-          <div class="flow-step">
+          <article class="flow-step">
             <span>4</span>
-            <strong>Prism restores response</strong>
-            <p>The application receives original values back after detokenization.</p>
-          </div>
+            <strong>Restore</strong>
+            <p>Inbound responses are scanned for Prism tokens and restored only after signature validation succeeds.</p>
+          </article>
         </div>
       </section>
     </main>
-
-    <script type="module" src="./app.js"></script>
+    <script src="./app.js"></script>
   </body>
 </html>

--- a/prism-dashboard/src/main/resources/META-INF/resources/prism/styles.css
+++ b/prism-dashboard/src/main/resources/META-INF/resources/prism/styles.css
@@ -1,17 +1,23 @@
 :root {
-  color-scheme: light;
-  --bg: #f4efe5;
-  --panel: rgba(255, 251, 245, 0.88);
-  --ink: #1e1a16;
-  --muted: #6d6258;
-  --accent: #0f766e;
-  --accent-strong: #134e4a;
-  --danger: #b42318;
-  --danger-strong: #8e1d13;
-  --warning: #c77800;
-  --info: #1d4ed8;
-  --shadow: 0 18px 40px rgba(65, 43, 24, 0.12);
-  font-family: "IBM Plex Sans", "Segoe UI", sans-serif;
+  color-scheme: dark;
+  --bg: #0b101e;
+  --bg-soft: #14192a;
+  --panel: rgba(20, 25, 42, 0.88);
+  --panel-strong: #151b2d;
+  --border: rgba(118, 140, 194, 0.18);
+  --ink: #f9fafb;
+  --muted: #9ca3af;
+  --muted-strong: #d1d5db;
+  --accent: #00d2b4;
+  --accent-strong: #10b981;
+  --accent-soft: rgba(0, 210, 180, 0.16);
+  --info: #3b82f6;
+  --warning: #f59e0b;
+  --danger: #f97316;
+  --danger-strong: #ef4444;
+  --shadow: 0 24px 70px rgba(2, 8, 23, 0.44);
+  --glow: 0 0 30px rgba(0, 210, 180, 0.12);
+  font-family: "Inter", "IBM Plex Sans", "Segoe UI", sans-serif;
 }
 
 * {
@@ -23,25 +29,43 @@ body {
   min-height: 100vh;
   color: var(--ink);
   background:
-      radial-gradient(circle at top left, rgba(15, 118, 110, 0.18), transparent 28%),
-      radial-gradient(circle at top right, rgba(180, 35, 24, 0.12), transparent 22%),
-      linear-gradient(180deg, #fdf8f2 0%, var(--bg) 100%);
+      radial-gradient(circle at top left, rgba(0, 210, 180, 0.14), transparent 28%),
+      radial-gradient(circle at top right, rgba(59, 130, 246, 0.14), transparent 22%),
+      linear-gradient(180deg, #0b101e 0%, #0e1423 100%);
+  background-image:
+      linear-gradient(to right, rgba(255, 255, 255, 0.025) 1px, transparent 1px),
+      linear-gradient(to bottom, rgba(255, 255, 255, 0.025) 1px, transparent 1px),
+      radial-gradient(circle at top left, rgba(0, 210, 180, 0.14), transparent 28%),
+      radial-gradient(circle at top right, rgba(59, 130, 246, 0.14), transparent 22%),
+      linear-gradient(180deg, #0b101e 0%, #0e1423 100%);
+  background-size: 48px 48px, 48px 48px, auto, auto, auto;
 }
 
-button {
+button,
+select {
   font: inherit;
 }
 
 code {
-  background: rgba(15, 23, 42, 0.08);
   border-radius: 999px;
   padding: 2px 8px;
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--muted-strong);
 }
 
 .dashboard-shell {
-  max-width: 1240px;
+  max-width: 1380px;
   margin: 0 auto;
-  padding: 48px 20px 64px;
+  padding: 40px 20px 64px;
+}
+
+.panel {
+  border: 1px solid var(--border);
+  border-radius: 24px;
+  background: var(--panel);
+  backdrop-filter: blur(16px);
+  box-shadow: var(--shadow);
+  padding: 22px;
 }
 
 .hero {
@@ -49,13 +73,13 @@ code {
   justify-content: space-between;
   gap: 24px;
   align-items: flex-start;
-  margin-bottom: 28px;
+  margin-bottom: 24px;
 }
 
 .eyebrow,
 .label {
   margin: 0 0 8px;
-  color: var(--accent-strong);
+  color: var(--accent);
   font-size: 0.78rem;
   font-weight: 700;
   letter-spacing: 0.16em;
@@ -70,106 +94,137 @@ code {
 
 .hero h1 {
   max-width: 760px;
-  font-size: clamp(2.3rem, 4vw, 4.3rem);
-  line-height: 0.96;
+  font-size: clamp(2.5rem, 4vw, 4.6rem);
+  line-height: 0.94;
 }
 
 .hero-copy {
   max-width: 760px;
   margin: 16px 0 0;
   color: var(--muted);
-  font-size: 1.05rem;
-  line-height: 1.6;
+  font-size: 1.04rem;
+  line-height: 1.65;
 }
 
 .hero-actions {
   display: flex;
   gap: 12px;
-  flex-wrap: wrap;
   align-items: center;
-  margin-top: 18px;
+  flex-wrap: wrap;
+  margin-top: 20px;
 }
 
-.mode-pill {
+.mode-pill,
+.score-window {
   display: inline-flex;
   align-items: center;
   padding: 10px 14px;
   border-radius: 999px;
-  background: rgba(19, 78, 74, 0.08);
-  color: var(--accent-strong);
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--muted-strong);
   font-size: 0.9rem;
   font-weight: 700;
 }
 
+.refresh-button,
+.demo-button,
+.secondary-button {
+  border-radius: 999px;
+  cursor: pointer;
+  transition:
+      transform 140ms ease,
+      background 140ms ease,
+      border-color 140ms ease;
+}
+
+.refresh-button:hover,
+.demo-button:hover,
+.secondary-button:hover {
+  transform: translateY(-1px);
+}
+
 .refresh-button {
   border: 0;
-  border-radius: 999px;
-  background: var(--accent);
-  color: white;
-  cursor: pointer;
-  padding: 12px 18px;
-  box-shadow: var(--shadow);
+  background: linear-gradient(135deg, var(--accent) 0%, var(--accent-strong) 100%);
+  color: #041413;
+  padding: 12px 20px;
+  font-weight: 700;
+  box-shadow: var(--glow);
 }
 
-.demo-button {
-  border: 1px solid rgba(15, 118, 110, 0.18);
-  border-radius: 999px;
-  background: rgba(255, 255, 255, 0.72);
-  color: var(--accent-strong);
-  cursor: pointer;
-  padding: 11px 16px;
-}
-
+.demo-button,
 .secondary-button {
-  border: 1px solid rgba(29, 24, 20, 0.12);
-  border-radius: 999px;
-  background: rgba(255, 255, 255, 0.8);
+  border: 1px solid var(--border);
+  background: rgba(255, 255, 255, 0.04);
   color: var(--ink);
-  cursor: pointer;
   padding: 11px 16px;
 }
 
 .ops-panel {
   margin-bottom: 20px;
+  border-radius: 999px;
+  padding: 16px 18px;
 }
 
 .ops-grid {
   display: grid;
-  grid-template-columns: repeat(7, minmax(0, 1fr));
-  gap: 16px;
+  grid-template-columns: repeat(9, minmax(0, 1fr));
+  gap: 14px;
   align-items: end;
 }
 
-.ops-grid label {
+.ops-grid label,
+.audit-toolbar label {
   display: grid;
   gap: 6px;
   color: var(--muted);
-  font-size: 0.9rem;
+  font-size: 0.86rem;
 }
 
-.ops-grid select {
-  border: 1px solid rgba(29, 24, 20, 0.12);
+.ops-grid select,
+.audit-toolbar select {
+  border: 1px solid var(--border);
   border-radius: 14px;
-  background: rgba(255, 255, 255, 0.82);
+  background: rgba(8, 12, 24, 0.84);
   padding: 10px 12px;
   color: var(--ink);
 }
 
+.ops-grid select:disabled {
+  opacity: 0.56;
+}
+
 .ops-actions {
   display: flex;
-  gap: 12px;
   flex-wrap: wrap;
+  gap: 10px;
   grid-column: span 2;
 }
 
-.ops-note {
-  margin: 14px 0 0;
+.ops-note,
+.audit-note,
+.history-note,
+.empty-state,
+.audit-empty,
+.score-explanation,
+.score-breakdown-card p,
+.trend-card span,
+.rollup-card span,
+.alert-card span,
+.entity-card span,
+.vault-card span,
+.integration-card span,
+.config-card span {
   color: var(--muted);
+}
+
+.status-panel {
+  margin-bottom: 20px;
 }
 
 .cards-grid {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-columns: 1.65fr 1fr 1fr;
   gap: 20px;
   margin-bottom: 20px;
 }
@@ -181,64 +236,189 @@ code {
   margin-bottom: 20px;
 }
 
-.panel {
-  border: 1px solid rgba(29, 24, 20, 0.08);
-  border-radius: 24px;
-  background: var(--panel);
-  backdrop-filter: blur(14px);
-  box-shadow: var(--shadow);
-  padding: 22px;
+.score-panel {
+  position: relative;
+  overflow: hidden;
+  border-color: rgba(0, 210, 180, 0.28);
+  box-shadow: var(--shadow), var(--glow);
 }
 
-.status-panel {
-  margin-bottom: 20px;
+.score-panel::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, rgba(0, 210, 180, 0.08), transparent 40%);
+  pointer-events: none;
+}
+
+.panel-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: flex-start;
+  margin-bottom: 18px;
+}
+
+.panel-header.compact {
+  margin-bottom: 12px;
+}
+
+.score-hero {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  grid-template-columns: 280px 1fr;
+  gap: 18px;
+  align-items: center;
+}
+
+.score-ring-shell {
+  display: grid;
+  place-items: center;
+}
+
+.score-ring {
+  --score: 0;
+  width: 236px;
+  height: 236px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  background:
+      radial-gradient(circle at center, rgba(11, 16, 30, 1) 57%, transparent 58%),
+      conic-gradient(
+          var(--accent-strong) 0deg,
+          #eab308 calc(var(--score) * 2.3deg),
+          var(--danger) calc(var(--score) * 3.6deg),
+          rgba(255, 255, 255, 0.08) 0deg);
+  box-shadow: inset 0 0 24px rgba(0, 210, 180, 0.12);
+}
+
+.score-ring-core {
+  width: 184px;
+  height: 184px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  text-align: center;
+  background: radial-gradient(circle at top, rgba(21, 27, 45, 0.98), rgba(10, 14, 28, 0.98));
+  border: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.score-ring-core strong {
+  font-size: 3.3rem;
+  line-height: 1;
+}
+
+.score-ring-core span {
+  color: var(--muted);
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+}
+
+.score-copy {
+  display: grid;
+  gap: 14px;
+}
+
+.score-breakdown {
+  display: grid;
+  gap: 12px;
+}
+
+.score-breakdown-card,
+.trend-card,
+.rollup-card,
+.alert-card,
+.entity-card,
+.vault-card,
+.integration-card,
+.config-card,
+.history-card,
+.audit-item,
+.audit-empty,
+.empty-state {
+  border-radius: 18px;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.score-breakdown-card {
+  padding: 14px 16px;
+}
+
+.score-breakdown-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 8px;
+  font-size: 0.95rem;
+}
+
+.score-breakdown-header strong {
+  color: var(--muted-strong);
+}
+
+.score-bar {
+  overflow: hidden;
+  height: 8px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.score-bar span {
+  display: block;
+  height: 100%;
+  width: 0;
+  border-radius: 999px;
+  background: linear-gradient(90deg, var(--accent) 0%, #38bdf8 100%);
 }
 
 .metric-card h2 {
-  font-size: 1.65rem;
+  font-size: 1.7rem;
   margin-bottom: 14px;
 }
 
-.metric-list {
+.metric-list,
+.ranking-list,
+.bars-list,
+.alert-grid,
+.entity-grid,
+.vault-grid,
+.integration-grid,
+.config-grid,
+.audit-list {
   display: grid;
   gap: 12px;
   margin: 0;
+  padding: 0;
 }
 
 .metric-list div,
-.ranking-list li {
+.ranking-list li,
+.mini-metrics div {
   display: flex;
   justify-content: space-between;
   gap: 12px;
 }
 
 .metric-list dt,
-.ranking-list span {
+.ranking-list span,
+.mini-metrics dt {
   color: var(--muted);
 }
 
 .metric-list dd,
-.ranking-list strong {
+.ranking-list strong,
+.mini-metrics dd {
   margin: 0;
   font-weight: 700;
 }
 
 .ranking-list {
   list-style: none;
-  margin: 0;
-  padding: 0;
-  display: grid;
-  gap: 10px;
-}
-
-.bars-list,
-.alert-grid,
-.entity-grid,
-.vault-grid,
-.integration-grid,
-.config-grid {
-  display: grid;
-  gap: 12px;
 }
 
 .trend-grid,
@@ -258,27 +438,16 @@ code {
   display: grid;
   gap: 8px;
   padding: 16px;
-  border-radius: 18px;
-  background: rgba(255, 255, 255, 0.72);
-  border: 1px solid rgba(29, 24, 20, 0.08);
 }
 
 .trend-card p,
-.trend-card span,
 .rollup-card p,
-.rollup-card span,
 .alert-card p,
-.alert-card span,
 .entity-card p,
-.entity-card span,
 .vault-card p,
-.vault-card span,
 .integration-card p,
-.integration-card span,
-.config-card p,
-.config-card span {
+.config-card p {
   margin: 0;
-  color: var(--muted);
 }
 
 .trend-card strong,
@@ -292,42 +461,27 @@ code {
 }
 
 .alert-critical {
-  border-color: rgba(142, 29, 19, 0.32);
-  background: rgba(180, 35, 24, 0.08);
+  border-color: rgba(249, 115, 22, 0.42);
+  background: rgba(249, 115, 22, 0.11);
 }
 
 .alert-warn {
-  border-color: rgba(199, 120, 0, 0.28);
-  background: rgba(199, 120, 0, 0.08);
+  border-color: rgba(245, 158, 11, 0.38);
+  background: rgba(245, 158, 11, 0.12);
 }
 
 .alert-healthy {
-  border-color: rgba(15, 118, 110, 0.22);
+  border-color: rgba(16, 185, 129, 0.24);
 }
 
 .alert-info {
-  border-color: rgba(29, 78, 216, 0.18);
+  border-color: rgba(59, 130, 246, 0.22);
 }
 
 .mini-metrics {
   display: grid;
   gap: 8px;
   margin: 0;
-}
-
-.mini-metrics div {
-  display: flex;
-  justify-content: space-between;
-  gap: 12px;
-}
-
-.mini-metrics dt {
-  color: var(--muted);
-}
-
-.mini-metrics dd {
-  margin: 0;
-  font-weight: 700;
 }
 
 .bar-row {
@@ -344,28 +498,24 @@ code {
 
 .bar-label span {
   color: var(--muted);
-  font-size: 0.92rem;
+  font-size: 0.88rem;
 }
 
 .bar-track {
   overflow: hidden;
-  height: 12px;
+  height: 10px;
   border-radius: 999px;
-  background: rgba(15, 118, 110, 0.12);
+  background: rgba(255, 255, 255, 0.08);
 }
 
 .bar-fill {
   height: 100%;
   border-radius: 999px;
-  background: linear-gradient(90deg, var(--accent) 0%, #1d9f94 100%);
+  background: linear-gradient(90deg, var(--accent) 0%, #38bdf8 100%);
 }
 
-.audit-list {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: grid;
-  gap: 10px;
+.audit-panel {
+  grid-column: span 3;
 }
 
 .audit-toolbar {
@@ -375,27 +525,6 @@ code {
   margin-bottom: 14px;
 }
 
-.audit-toolbar label {
-  display: grid;
-  gap: 6px;
-  color: var(--muted);
-  font-size: 0.88rem;
-}
-
-.audit-toolbar select {
-  border: 1px solid rgba(29, 24, 20, 0.12);
-  border-radius: 14px;
-  background: rgba(255, 255, 255, 0.82);
-  padding: 10px 12px;
-  color: var(--ink);
-}
-
-.audit-note {
-  margin: 0 0 12px;
-  color: var(--muted);
-  font-size: 0.92rem;
-}
-
 .audit-item,
 .audit-empty,
 .empty-state {
@@ -403,16 +532,12 @@ code {
   justify-content: space-between;
   gap: 14px;
   padding: 14px;
-  border-radius: 18px;
-  background: rgba(255, 255, 255, 0.7);
-  border: 1px solid rgba(29, 24, 20, 0.08);
 }
 
 .audit-item p,
 .audit-empty,
 .empty-state {
   margin: 6px 0 0;
-  color: var(--muted);
 }
 
 .audit-item time {
@@ -425,14 +550,6 @@ code {
   margin-bottom: 20px;
 }
 
-.panel-header {
-  margin-bottom: 18px;
-  display: flex;
-  justify-content: space-between;
-  gap: 16px;
-  align-items: flex-start;
-}
-
 .history-grid {
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
@@ -441,9 +558,6 @@ code {
 
 .history-card {
   padding: 16px;
-  border-radius: 18px;
-  background: rgba(255, 255, 255, 0.72);
-  border: 1px solid rgba(29, 24, 20, 0.08);
 }
 
 .history-card p {
@@ -455,17 +569,6 @@ code {
   width: 100%;
   height: auto;
   overflow: visible;
-}
-
-.history-note {
-  margin: 0;
-  color: var(--muted);
-  max-width: 340px;
-  text-align: right;
-}
-
-.flow-panel {
-  overflow: hidden;
 }
 
 .flow-grid {
@@ -483,10 +586,10 @@ code {
 }
 
 .flow-step {
-  background: rgba(255, 255, 255, 0.72);
-  border: 1px solid rgba(29, 24, 20, 0.08);
-  border-radius: 20px;
   padding: 18px 14px;
+  border-radius: 20px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.06);
 }
 
 .flow-step span {
@@ -496,9 +599,13 @@ code {
   height: 32px;
   margin-bottom: 10px;
   border-radius: 999px;
-  background: var(--accent);
-  color: white;
-  font-weight: 700;
+  background: linear-gradient(135deg, var(--accent) 0%, var(--accent-strong) 100%);
+  color: #041413;
+  font-weight: 800;
+}
+
+.flow-step strong {
+  font-size: 1rem;
 }
 
 .flow-step p {
@@ -509,49 +616,48 @@ code {
 }
 
 .flow-arrow {
-  font-size: 2rem;
-  color: var(--accent-strong);
+  font-size: 1.9rem;
+  color: rgba(255, 255, 255, 0.32);
 }
 
 .error-panel {
-  border-color: rgba(180, 35, 24, 0.22);
+  border-color: rgba(249, 115, 22, 0.34);
+  background: rgba(249, 115, 22, 0.12);
 }
 
 .hidden {
   display: none;
 }
 
-@media (max-width: 1080px) {
-  .ops-grid,
+@media (max-width: 1180px) {
+  .cards-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .score-hero {
+    grid-template-columns: 1fr;
+  }
+
   .analytics-grid,
-  .cards-grid,
   .history-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
-  .ops-actions {
+  .audit-panel {
     grid-column: span 2;
   }
 }
 
-@media (max-width: 940px) {
-  .hero,
+@media (max-width: 1040px) {
+  .ops-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .ops-actions {
+    grid-column: span 3;
+  }
+
   .flow-grid {
-    grid-template-columns: 1fr;
-    display: grid;
-  }
-
-  .hero {
-    align-items: stretch;
-  }
-
-  .refresh-button {
-    justify-self: start;
-  }
-
-  .trend-grid,
-  .rollup-grid,
-  .audit-toolbar {
     grid-template-columns: 1fr;
   }
 
@@ -560,28 +666,27 @@ code {
   }
 }
 
-@media (max-width: 640px) {
+@media (max-width: 760px) {
   .dashboard-shell {
     padding: 28px 16px 48px;
   }
 
-  .ops-grid,
-  .cards-grid,
-  .analytics-grid,
-  .history-grid {
+  .hero {
+    display: grid;
     grid-template-columns: 1fr;
   }
 
+  .analytics-grid,
+  .history-grid,
+  .audit-toolbar,
+  .trend-grid,
+  .rollup-grid,
+  .ops-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .audit-panel,
   .ops-actions {
     grid-column: span 1;
-    flex-direction: column;
-  }
-
-  .panel-header {
-    flex-direction: column;
-  }
-
-  .history-note {
-    text-align: left;
   }
 }

--- a/prism-spring-boot-starter/src/main/java/io/github/catalin87/prism/boot/autoconfigure/PrismMetricsSnapshot.java
+++ b/prism-spring-boot-starter/src/main/java/io/github/catalin87/prism/boot/autoconfigure/PrismMetricsSnapshot.java
@@ -23,6 +23,7 @@ public record PrismMetricsSnapshot(
     long tokenizedCount,
     long detokenizedCount,
     long detectionErrorCount,
+    PrivacyScore privacyScore,
     Map<String, Long> detectionCounts,
     Map<String, PrismRuntimeMetrics.DurationMetric> durationMetrics,
     List<RulePackMetric> rulePackMetrics,

--- a/prism-spring-boot-starter/src/main/java/io/github/catalin87/prism/boot/autoconfigure/PrismMetricsSnapshotFactory.java
+++ b/prism-spring-boot-starter/src/main/java/io/github/catalin87/prism/boot/autoconfigure/PrismMetricsSnapshotFactory.java
@@ -87,10 +87,13 @@ final class PrismMetricsSnapshotFactory {
         Math.max(0, prismRuntimeMetrics.tokenizedCount() - prismRuntimeMetrics.detokenizedCount());
     DashboardConfiguration dashboardConfiguration =
         dashboardConfiguration(prismRuntimeMetrics, properties);
+    PrivacyScore privacyScore =
+        privacyScore(historySamples, tokenBacklog, prismVault, properties, prismRuntimeMetrics);
     return new PrismMetricsSnapshot(
         prismRuntimeMetrics.tokenizedCount(),
         prismRuntimeMetrics.detokenizedCount(),
         prismRuntimeMetrics.detectionErrorCount(),
+        privacyScore,
         detectionCounts,
         durationMetrics,
         rulePackMetrics,
@@ -161,5 +164,122 @@ final class PrismMetricsSnapshotFactory {
         errorEvents,
         averageScanMilliseconds,
         peakTokenBacklog);
+  }
+
+  private static PrivacyScore privacyScore(
+      List<HistorySample> historySamples,
+      long tokenBacklog,
+      PrismVault prismVault,
+      SpringPrismProperties properties,
+      PrismRuntimeMetrics prismRuntimeMetrics) {
+    Instant now = Instant.now();
+    List<HistorySample> lastHourSamples = within(historySamples, now, Duration.ofHours(1));
+    List<HistorySample> scoringSamples =
+        lastHourSamples.isEmpty() ? historySamples : lastHourSamples;
+
+    long protectedActivity = recentProtectedActivity(scoringSamples);
+    long recentErrors = recentErrors(scoringSamples);
+    double coverage = clamp01(protectedActivity / 20d);
+    double reliability = 1d - clamp01(recentErrors / (double) Math.max(1L, protectedActivity));
+    double posture = postureScore(prismVault, properties, prismRuntimeMetrics, tokenBacklog);
+
+    int coverageScore = toScore(coverage);
+    int reliabilityScore = toScore(reliability);
+    int postureScore = toScore(posture);
+    int overallScore = toScore((0.50d * coverage) + (0.30d * reliability) + (0.20d * posture));
+
+    return new PrivacyScore(
+        overallScore,
+        "Last 60 minutes",
+        "Based on protected activity, runtime reliability, and deployment posture "
+            + "in the last 60 minutes.",
+        new PrivacyScoreComponent(
+            "Coverage",
+            coverageScore,
+            protectedActivity > 0
+                ? protectedActivity + " protected event(s) observed in the active window."
+                : "Waiting for protected traffic in the active window."),
+        new PrivacyScoreComponent(
+            "Reliability",
+            reliabilityScore,
+            recentErrors > 0
+                ? recentErrors + " error event(s) reduced the runtime reliability score."
+                : "No recent detector, vault, or restore errors reduced the score."),
+        new PrivacyScoreComponent(
+            "Posture",
+            postureScore,
+            postureDetail(prismVault, properties, prismRuntimeMetrics, tokenBacklog)));
+  }
+
+  private static long recentProtectedActivity(List<HistorySample> samples) {
+    if (samples.isEmpty()) {
+      return 0L;
+    }
+    HistorySample first = samples.getFirst();
+    HistorySample last = samples.getLast();
+    long detectionDelta = Math.max(0L, last.totalDetections() - first.totalDetections());
+    long tokenizedDelta = Math.max(0L, last.tokenizedCount() - first.tokenizedCount());
+    if (samples.size() == 1) {
+      return Math.max(last.totalDetections(), last.tokenizedCount());
+    }
+    return Math.max(detectionDelta, tokenizedDelta);
+  }
+
+  private static long recentErrors(List<HistorySample> samples) {
+    if (samples.isEmpty()) {
+      return 0L;
+    }
+    HistorySample first = samples.getFirst();
+    HistorySample last = samples.getLast();
+    if (samples.size() == 1) {
+      return last.detectionErrors();
+    }
+    return Math.max(0L, last.detectionErrors() - first.detectionErrors());
+  }
+
+  private static double postureScore(
+      PrismVault prismVault,
+      SpringPrismProperties properties,
+      PrismRuntimeMetrics prismRuntimeMetrics,
+      long tokenBacklog) {
+    double score = 0.55d;
+    score += properties.isSecurityStrictMode() ? 0.15d : 0.05d;
+    score += prismVault.getClass().getSimpleName().toLowerCase().contains("redis") ? 0.20d : 0.15d;
+    score += "spring-prism-change-me".equals(properties.getAppSecret()) ? -0.20d : 0.10d;
+    if (tokenBacklog == 0L) {
+      score += 0.05d;
+    } else if (tokenBacklog > prismRuntimeMetrics.auditRetentionLimit()) {
+      score -= 0.05d;
+    }
+    return clamp01(score);
+  }
+
+  private static String postureDetail(
+      PrismVault prismVault,
+      SpringPrismProperties properties,
+      PrismRuntimeMetrics prismRuntimeMetrics,
+      long tokenBacklog) {
+    String strictMode = properties.isSecurityStrictMode() ? "strict mode on" : "fail-open mode";
+    String vaultMode =
+        prismVault.getClass().getSimpleName().toLowerCase().contains("redis")
+            ? "Redis-backed shared vault"
+            : "local in-memory vault";
+    String secretState =
+        "spring-prism-change-me".equals(properties.getAppSecret())
+            ? "default app secret still configured"
+            : "custom app secret configured";
+    String backlogState =
+        tokenBacklog > prismRuntimeMetrics.auditRetentionLimit()
+            ? "token backlog is elevated"
+            : "token backlog is within the normal band";
+    return strictMode + ", " + vaultMode + ", " + secretState + ", and " + backlogState + ".";
+  }
+
+  private static int toScore(double value) {
+    return (int) Math.round(clamp01(value) * 100d);
+  }
+
+  private static double clamp01(double value) {
+    return Math.max(0d, Math.min(1d, value));
   }
 }

--- a/prism-spring-boot-starter/src/main/java/io/github/catalin87/prism/boot/autoconfigure/PrivacyScore.java
+++ b/prism-spring-boot-starter/src/main/java/io/github/catalin87/prism/boot/autoconfigure/PrivacyScore.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2026 Catalin Dordea and Spring Prism Contributors
+ *
+ * Licensed under the EUPL, Version 1.2 or later (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and
+ * limitations under the Licence.
+ */
+package io.github.catalin87.prism.boot.autoconfigure;
+
+/** Immutable privacy score snapshot rendered by the embedded dashboard. */
+public record PrivacyScore(
+    int score,
+    String windowLabel,
+    String explanation,
+    PrivacyScoreComponent coverage,
+    PrivacyScoreComponent reliability,
+    PrivacyScoreComponent posture) {}

--- a/prism-spring-boot-starter/src/main/java/io/github/catalin87/prism/boot/autoconfigure/PrivacyScoreComponent.java
+++ b/prism-spring-boot-starter/src/main/java/io/github/catalin87/prism/boot/autoconfigure/PrivacyScoreComponent.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2026 Catalin Dordea and Spring Prism Contributors
+ *
+ * Licensed under the EUPL, Version 1.2 or later (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and
+ * limitations under the Licence.
+ */
+package io.github.catalin87.prism.boot.autoconfigure;
+
+/** Immutable scored dashboard component used by the privacy score gauge. */
+public record PrivacyScoreComponent(String label, int score, String detail) {}

--- a/prism-spring-boot-starter/src/test/java/io/github/catalin87/prism/boot/autoconfigure/SpringPrismAutoConfigurationTest.java
+++ b/prism-spring-boot-starter/src/test/java/io/github/catalin87/prism/boot/autoconfigure/SpringPrismAutoConfigurationTest.java
@@ -204,6 +204,9 @@ class SpringPrismAutoConfigurationTest {
           PrismActuatorEndpoint endpoint = context.getBean(PrismActuatorEndpoint.class);
           PrismMetricsSnapshot snapshot = endpoint.metrics();
 
+          assertThat(snapshot.privacyScore()).isNotNull();
+          assertThat(snapshot.privacyScore().score()).isBetween(0, 100);
+          assertThat(snapshot.privacyScore().coverage().label()).isEqualTo("Coverage");
           assertThat(snapshot.activeRulePacks()).contains("UNIVERSAL");
           assertThat(snapshot.vaultType()).isNotBlank();
           assertThat(snapshot.durationMetrics())

--- a/website/docs/architecture.md
+++ b/website/docs/architecture.md
@@ -51,7 +51,7 @@ The embedded observability surface.
 - **Packaging**: Static assets are served from `META-INF/resources/prism/` inside the dashboard jar.
 - **Data Source**: Reads the Prism runtime snapshot from `/actuator/prism` when Actuator is present and falls back to `/prism/metrics` otherwise.
 - **Verification**: Includes a bundled `/prism/?demo=1` fixture mode for visual checks without a live runtime.
-- **Current Scope**: Dashboard shell, top-redacted metrics, vault/runtime health, rule-pack activity bars, integration timing cards, threshold-aware alerts, vault posture cards, entity drill-downs, server-side retained history charts, rollup cards, operational filters, JSON/CSV/incident exports, a masked recent-activity audit feed with filters, and a visual refraction-flow explainer.
+- **Current Scope**: Dashboard shell, a live Privacy Score, top-redacted metrics, vault/runtime health, rule-pack activity bars, integration timing cards, threshold-aware alerts, vault posture cards, entity drill-downs, server-side retained history charts, rollup cards, operational filters, JSON/CSV/incident exports, a masked recent-activity audit feed with filters, and a visual refraction-flow explainer.
 - **Operational Guidance**: The dashboard payload stays masked, but the routes remain operational endpoints and should be protected by the host application's normal security boundary in production. Dashboard defaults and thresholds are configured centrally under `spring.prism.dashboard.*`.
 
 ## The Request Lifecycle

--- a/website/docs/dashboard.md
+++ b/website/docs/dashboard.md
@@ -18,6 +18,7 @@ If Actuator is not on the classpath, it falls back to:
 
 ## Current panels
 
+- Global Privacy Score with live Coverage, Reliability, and Posture subscores over the last 60 minutes
 - Vault health and tokenization counts
 - Top redacted entity types
 - Runtime pulse and tracked timer count
@@ -34,6 +35,28 @@ If Actuator is not on the classpath, it falls back to:
 - Polling controls plus JSON, CSV, and incident-summary export
 - Operational filters for integration, rule pack, entity type, and trend window
 - Refraction-flow explainer
+
+## Privacy Score
+
+The dashboard now renders a live `Privacy Score` as the primary hero signal.
+
+It is calculated from the last 60 minutes of retained dashboard history using:
+
+```text
+PrivacyScore = 100 * (
+  0.50 * Coverage +
+  0.30 * Reliability +
+  0.20 * Posture
+)
+```
+
+Where:
+
+- `Coverage` reflects recent protected activity
+- `Reliability` penalizes recent detector and restore errors
+- `Posture` reflects strict-mode, vault mode, secret hygiene, and backlog posture
+
+The goal is not to pretend the score is a universal security grade. It is a live operational signal that makes Prism's recent value and runtime health immediately visible.
 
 ## Dashboard configuration
 

--- a/website/docs/release-readiness.md
+++ b/website/docs/release-readiness.md
@@ -44,6 +44,7 @@ The current verification baseline covers:
 - starter auto-configuration tests, including Redis-absent startup safety
 - runnable Spring AI, LangChain4j, and MCP example applications that boot and prove redaction/restoration
 - a dedicated `prism-benchmarks` JMH module for scan, vault, streaming, and Redis-vault measurements
+- embedded dashboard coverage for the redesigned control-plane UI and live Privacy Score rendering
 
 ## Release Profile
 


### PR DESCRIPTION
## Summary
- redesign the embedded dashboard to match the new control-plane visual direction
- add a live Global Privacy Score with Coverage, Reliability, and Posture components
- sync dashboard architecture and release-readiness docs for the 1.0.0 release scope

## Verification
- mvn -Dmaven.repo.local=/tmp/spring-prism-m2 -pl prism-spring-boot-starter,prism-dashboard -am test -DskipITs
- cd website && npm run build