### PR TITLE
docs: align Central metadata and licensing

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -15,6 +15,8 @@ You may use this software by choosing **one** of the two licensing options descr
 ### Option A: Open-Source Community License
 **License:** [European Union Public Licence (EUPL) version 1.2](https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12)
 
+Artifacts published to Maven Central are publicly distributed under the open-source EUPL 1.2 terms, while the repository and project itself remain available under the dual-licensing model documented in this file.
+
 This option is intended for developers and open-source projects. Please be aware of the following:
 * **Strong Reciprocity (Copyleft):** Any derivative works must be distributed under the same terms.
 * **Network Distribution (Closing the "SaaS Loophole"):** Under Article 1 of the EUPL 1.2, providing access to the software’s essential functionalities over a network (Software-as-a-Service model) constitutes a "Distribution" or "Communication to the Public." This triggers the obligation to make the source code of any modifications available to users.
@@ -346,4 +348,3 @@ Code from exclusive appropriation.
 
 All other changes or additions to this Appendix require the production of a new
 EUPL version.
-

--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,12 @@
             <url>https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12</url>
             <distribution>repo</distribution>
         </license>
+        <license>
+            <name>Commercial License</name>
+            <url>https://github.com/catalin87/spring-prism/blob/main/LICENSE.md</url>
+            <distribution>manual</distribution>
+            <comments>Spring Prism is dual-licensed. Commercial licensing terms are documented in LICENSE.md.</comments>
+        </license>
     </licenses>
 
     <organization>
@@ -26,6 +32,7 @@
         <developer>
             <id>catalin87</id>
             <name>Catalin Dordea</name>
+            <email>catalin87@gmail.com</email>
             <url>https://github.com/catalin87</url>
         </developer>
     </developers>


### PR DESCRIPTION
## Summary
- add developer email to Maven Central metadata
- declare dual licensing in pom metadata
- clarify Maven Central OSS artifact licensing in LICENSE.md

## Verification
- metadata and documentation change only
